### PR TITLE
UI fix editors leaderboard

### DIFF
--- a/src/components/InsitghtAllstats.tsx
+++ b/src/components/InsitghtAllstats.tsx
@@ -60,11 +60,13 @@ const MyComponent = () => {
       >
         <Text
           color={"#30A0E0"}
-          fontSize="3xl"
+          fontSize="2xl"
           fontWeight="bold"
           textAlign="center"
           // marginBottom="0.5rem"
           paddingTop={5}
+          width="100%"
+          wordWrap="break-word"
         >
           Editors Leaderboard
         </Text>

--- a/src/components/InsitghtAllstats.tsx
+++ b/src/components/InsitghtAllstats.tsx
@@ -60,13 +60,11 @@ const MyComponent = () => {
       >
         <Text
           color={"#30A0E0"}
-          fontSize="2xl"
+          fontSize="3xl"
           fontWeight="bold"
           textAlign="center"
           // marginBottom="0.5rem"
           paddingTop={5}
-          width="100%"
-          wordWrap="break-word"
         >
           Editors Leaderboard
         </Text>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/7665dbb1-5607-4eab-8c43-a9f0564688d3)


Fix for the 'Editors LeaderBoard' OutOfBoounds problem as shown in the image
following change was made:

src > components > InsightAllStats.tsx > MyComponent

<Text
          color={"#30A0E0"}
     -     // fontSize="2xl"
     +    fontSize="2xl"
          fontWeight="bold"
          textAlign="center"
          // marginBottom="0.5rem"
          paddingTop={5}
     +     width="100%"
     +    wordWrap="break-word"
        >
          Editors Leaderboard
        </Text>