### PR TITLE
Refactor Discord webhook handling to use environment variables instead of hardcoded values

### DIFF
--- a/src/pages/api/Feedback/enhanced-feedback.tsx
+++ b/src/pages/api/Feedback/enhanced-feedback.tsx
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { MongoClient } from "mongodb";
 
-const DISCORD_WEBHOOK_URL = "https://discord.com/api/webhooks/1423745692366672044/65Y9iEFzVKFBN0cXbZWmEYOAV5kqAiX0wuYLlh4KjyXAtS5JlCN6uSV954NfDK-DUjEV";
+const DISCORD_WEBHOOK_URL = process.env.DISCORD_WEB";
 
 interface FeedbackData {
   rating: 'positive' | 'neutral' | 'negative';

--- a/src/pages/api/Feedback/feedback.tsx
+++ b/src/pages/api/Feedback/feedback.tsx
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { MongoClient } from "mongodb";
 
-const DISCORD_WEBHOOK_URL = "https://discord.com/api/webhooks/1423745692366672044/65Y9iEFzVKFBN0cXbZWmEYOAV5kqAiX0wuYLlh4KjyXAtS5JlCN6uSV954NfDK-DUjEV";
+const DISCORD_WEBHOOK_URL = process.env.DISCORD_WEB";
 
 async function sendDiscordNotification(feedbackData: any) {
   try {

--- a/src/pages/api/test-discord-webhook.ts
+++ b/src/pages/api/test-discord-webhook.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
-const DISCORD_WEBHOOK_URL = "https://discord.com/api/webhooks/1423745692366672044/65Y9iEFzVKFBN0cXbZWmEYOAV5kqAiX0wuYLlh4KjyXAtS5JlCN6uSV954NfDK-DUjEV";
+const DISCORD_WEBHOOK_URL = process.env.DISCORD_WEB";
 
 export default async function handler(
   req: NextApiRequest,


### PR DESCRIPTION
This pull request updates how the Discord webhook URL is managed in the API endpoints by switching from a hardcoded string to using an environment variable. This change improves security and flexibility, making it easier to manage secrets and configuration across environments.

Configuration improvements:

* Replaced the hardcoded `DISCORD_WEBHOOK_URL` with `process.env.DISCORD_WEB` in `src/pages/api/Feedback/enhanced-feedback.tsx`, `src/pages/api/Feedback/feedback.tsx`, and `src/pages/api/test-discord-webhook.ts`, ensuring the webhook URL is now sourced from environment variables instead of being exposed in the codebase. [[1]](diffhunk://#diff-78d78b9ee938a43cc36f7ef3c7fa8951c1ddbb6893cf916f46290ced5dd11f1fL4-R4) [[2]](diffhunk://#diff-94d7a13bf5ed040c956e06c0625bb191eb9f87e01d8b1deb80be68907cabb3c1L4-R4) [[3]](diffhunk://#diff-2efe1620c8530ad49bb146aa448100c6b206a67dabddfde33b19707a44d81f99L3-R3)