### PR TITLE
refactor: add null checks for Discord webhook URL in feedback endpoints

### DIFF
--- a/src/pages/api/Feedback/enhanced-feedback.tsx
+++ b/src/pages/api/Feedback/enhanced-feedback.tsx
@@ -12,6 +12,11 @@ interface FeedbackData {
 
 async function sendDiscordNotification(feedbackData: any) {
   try {
+    if (!DISCORD_WEBHOOK_URL) {
+      console.log("Discord webhook URL not configured, skipping notification");
+      return;
+    }
+
     // Map ratings to emojis and colors
     const ratingMap: Record<string, { emoji: string; color: number; text: string }> = {
       'positive': { emoji: '👍', color: 0x00ff00, text: 'Positive' },
@@ -61,6 +66,7 @@ async function sendDiscordNotification(feedbackData: any) {
         inline: false
       });
     }
+    
 
     await fetch(DISCORD_WEBHOOK_URL, {
       method: "POST",

--- a/src/pages/api/Feedback/feedback.tsx
+++ b/src/pages/api/Feedback/feedback.tsx
@@ -4,6 +4,11 @@ import { MongoClient } from "mongodb";
 const DISCORD_WEBHOOK_URL = process.env.DISCORD_WEB;
 
 async function sendDiscordNotification(feedbackData: any) {
+  if (!DISCORD_WEBHOOK_URL) {
+    console.warn("Discord webhook URL not configured, skipping notification");
+    return;
+  }
+
   try {
     const embed = {
       title: "🔔 New Feedback Received",

--- a/src/pages/api/test-discord-webhook.ts
+++ b/src/pages/api/test-discord-webhook.ts
@@ -10,6 +10,10 @@ export default async function handler(
     return res.status(405).json({ message: "Method not allowed" });
   }
 
+  if (!DISCORD_WEBHOOK_URL) {
+    return res.status(500).json({ message: "Discord webhook URL not configured" });
+  }
+
   try {
     const embed = {
       title: "🧪 Test Notification",


### PR DESCRIPTION
This pull request improves the robustness of Discord notification handling by ensuring that the Discord webhook URL is properly configured before attempting to send notifications. It adds checks in multiple API routes to prevent errors and unnecessary requests when the webhook URL is missing.

**Discord webhook configuration checks:**

* Added a check in `sendDiscordNotification` in `src/pages/api/Feedback/enhanced-feedback.tsx` to log a message and skip sending notifications if `DISCORD_WEBHOOK_URL` is not set.
* Added a similar check in `sendDiscordNotification` in `src/pages/api/Feedback/feedback.tsx` to warn and skip notification if `DISCORD_WEBHOOK_URL` is missing.
* In `src/pages/api/test-discord-webhook.ts`, added a check to return a 500 error if `DISCORD_WEBHOOK_URL` is not configured, preventing test notifications from being sent without a valid webhook.

**Code clarity and error prevention:**

* Minor formatting improvement in `sendDiscordNotification` in `src/pages/api/Feedback/enhanced-feedback.tsx` for better readability.- Added validation to check if DISCORD_WEBHOOK_URL is configured before sending notifications
- Returns early with console log/warning in enhanced-feedback.tsx and feedback.tsx when webhook URL is missing
- Returns 500 error response in test-discord-webhook.ts when webhook URL is not configured
- Prevents runtime errors when Discord webhook environment variable is not set