### PR TITLE
refactor: standardize '/about' route to '/About' across components

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -15,6 +15,11 @@ export function middleware(request: NextRequest) {
     return NextResponse.redirect(new URL('/Analytics', request.url));
   }
 
+  if (path.toLowerCase() === '/about') {
+    console.log("redirected");
+    return NextResponse.redirect(new URL('/About', request.url));
+  }
+
 
   return NextResponse.next();
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -171,7 +171,7 @@ export default function LargeWithAppLinksAndSocial() {
                   </Box>
                   
                   <Box>
-                    <NextLink href="/about">
+                    <NextLink href="/About">
                       <Text 
                         _hover={{ color: useColorModeValue("blue.600", "blue.300"), transform: "translateX(2px)" }} 
                         cursor="pointer"

--- a/src/components/Resources2.tsx
+++ b/src/components/Resources2.tsx
@@ -183,7 +183,7 @@ const INSIGHT= [
       image: "Blockchain_Future.png",
       title: "What is EIPsInsight?",
       content: "EIPsInsight is specialized in toolings designed to provide clear, visual insights into the activity of Ethereum Improvement Proposals (EIPs),  Ethereum Request for Comments (ERCs), Rollup Improvement Proposals (RIPs) over a specified period.",
-      link: "/about"
+      link: "/About"
   },
  
 ]

--- a/src/components/Resources3.tsx
+++ b/src/components/Resources3.tsx
@@ -242,7 +242,7 @@ const ResourcesPage: React.FC = () => {
       title: "What is EIPsInsight?",
       content:
         "EIPsInsight is specialized in toolings designed to provide clear, visual insights into the activity of Ethereum Improvement Proposals (EIPs), Ethereum Request for Comments (ERCs), and Rollup Improvement Proposals (RIPs) over a specified period.",
-      link: "/about",
+      link: "/About",
       tag: "About",
     },
   ];

--- a/src/components/Sidebar/slidebarConfig.ts
+++ b/src/components/Sidebar/slidebarConfig.ts
@@ -38,7 +38,7 @@ import {
 export const sidebarGroupIcons: Record<string, React.ElementType> = {
   "/": LuHome,
   "/home": LuHome,
-  "/about": LuInfo,
+  "/About": LuInfo,
   "/all": LuSearch,
   "/milestones2024": LuClipboardList,
   "/trivia": LuSparkles,
@@ -71,7 +71,7 @@ export const sidebarConfig: Record<
     { label: "Dashboard", icon: LuDatabase, id: "dashboard" },
     { label: "Latest Updates", icon: LuRocket, id: "latest-updates" },
   ],
-  "/about": [{ label: "What is EIPs Insights", icon: LuInfo, id: "what" }],
+  "/About": [{ label: "What is EIPs Insights", icon: LuInfo, id: "what" }],
   "/resources": [{ label: "What is EIPs Insights", icon: LuInfo, id: "what" }],
   // "/all": [
   //   { label: "Search EIP", icon: LuSearch, id: "searchEIP" },

--- a/src/components/SlotCountdown.tsx
+++ b/src/components/SlotCountdown.tsx
@@ -61,8 +61,9 @@ const networks: Record<string, NetworkConfig> = {
   mainnet: {
     beaconApi: "https://ethereum-beacon-api.publicnode.com",
     rpc: "https://ethereum-rpc.publicnode.com",
-    target: Number.MAX_SAFE_INTEGER,
-    targetepoch: Number.MAX_SAFE_INTEGER,
+    // Fusaka activation
+    target: 13164544,
+    targetepoch: Math.floor(13164544 / 32), // 411454
     name: "Mainnet",
   },
 };
@@ -70,18 +71,18 @@ const networks: Record<string, NetworkConfig> = {
 const FUSAKA_INFO = {
   title: "FUSAKA Network Upgrade",
   description:
-    "Ethereum's next major upgrade focusing on enhanced blob throughput and network efficiency.",
+    "Ethereum's major hard fork focused on improving scalability, efficiency, and security through PeerDAS and increased capacity.",
   features: [
-    "Increased blob capacity for Layer 2 scaling",
-    "Improved data availability for rollups",
-    "Network optimization and efficiency improvements",
-    "Enhanced security and validator performance",
+    "PeerDAS: Peer Data Availability Sampling for efficient data verification",
+    "Block gas limit increased from 30M to 150M units",
+    "Doubled blob capacity through BPO (Blob Parameter Only) forks",
+    "Reduced network congestion and lower transaction fees for L2 rollups",
   ],
   schedule: {
     holesky: "October 1, 2025 - 08:48 UTC",
     sepolia: "October 14, 2025 - 07:36 UTC",
     hoodi: "October 28, 2025 - 18:53 UTC",
-    mainnet: "To be announced after testnet completion",
+    mainnet: "December 4, 2025 - 05:49:11 UTC",
   },
   readMore: {
     label: "Read more about FUSAKA",
@@ -100,6 +101,7 @@ const getAccent = (network: string, light: boolean) => {
   if (network === "holesky") return light ? "blue.600" : "blue.300";
   if (network === "sepolia") return light ? "purple.600" : "purple.300";
   if (network === "hoodi") return light ? "orange.600" : "orange.300";
+  if (network === "mainnet") return light ? "blue.700" : "blue.400";
   return light ? "gray.700" : "gray.200";
 };
 
@@ -108,7 +110,7 @@ const SlotCountdown: React.FC = () => {
   const [currentEpoch, setCurrentEpoch] = useState<number>(0);
   const [currentBlock, setCurrentBlock] = useState<number>(0);
   const [timer, setTimer] = useState<number>(13);
-  const [network, setNetwork] = useState<keyof typeof networks>("hoodi");
+  const [network, setNetwork] = useState<keyof typeof networks>("mainnet");
   const [loading, setLoading] = useState<boolean>(true);
   const [countdown, setCountdown] = useState<string>("");
   const [isUpgradeLive, setIsUpgradeLive] = useState<boolean>(false);
@@ -742,8 +744,8 @@ const SlotCountdown: React.FC = () => {
           <Text fontSize={{ base: "lg", md: "xl" }} fontWeight="bold" color={useColorModeValue("gray.800", "white")}>
             Live Countdown — {networks[network].name} Network
           </Text>
-          <Badge colorScheme={network === "mainnet" ? "gray" : "green"} fontSize="xs" px={2}>
-            {network === "mainnet" ? "TBD" : "TESTNET"}
+          <Badge colorScheme={network === "mainnet" ? "blue" : "green"} fontSize="xs" px={2}>
+            {network === "mainnet" ? "MAINNET" : "TESTNET"}
           </Badge>
         </HStack>
         <Select
@@ -768,7 +770,7 @@ const SlotCountdown: React.FC = () => {
           {(["holesky", "sepolia", "hoodi", "mainnet"] as (keyof typeof networks)[]).map((net) => (
             <Button
               key={net}
-              colorScheme={network === net ? (net === "mainnet" ? "gray" : net === "hoodi" ? "orange" : net === "sepolia" ? "purple" : "blue") : "gray"}
+              colorScheme={network === net ? (net === "mainnet" ? "blue" : net === "hoodi" ? "orange" : net === "sepolia" ? "purple" : "blue") : "gray"}
               onClick={() => handleNetworkChange(net)}
               variant={network === net ? "solid" : "outline"}
               size="sm"
@@ -777,7 +779,7 @@ const SlotCountdown: React.FC = () => {
             >
               {net.charAt(0).toUpperCase() + net.slice(1)}
               {net === "holesky" && <Badge ml={1} colorScheme="orange" fontSize="9px" variant="subtle">FINAL</Badge>}
-              {net === "mainnet" && <Badge ml={1} colorScheme="gray" fontSize="9px" variant="subtle">TBD</Badge>}
+              {net === "mainnet" && <Badge ml={1} colorScheme="blue" fontSize="9px" variant="subtle">DEC 4</Badge>}
             </Button>
           ))}
         </HStack>
@@ -790,26 +792,6 @@ const SlotCountdown: React.FC = () => {
           <Text color={useColorModeValue("gray.600", "gray.400")} fontSize="sm">
             Loading {networks[network].name} network data...
           </Text>
-        </VStack>
-      ) : network === "mainnet" ? (
-        <VStack spacing={4}>
-          <HStack justify="center" spacing={4} flexWrap="wrap" py={2}>
-            <Text fontSize="sm" color={useColorModeValue("gray.600", "gray.400")}>
-              Mainnet Date: TBD
-            </Text>
-            <Text fontSize="sm" color={useColorModeValue("gray.600", "gray.400")}>•</Text>
-            <Text fontSize="sm" color={useColorModeValue("gray.600", "gray.400")}>
-              Block: {currentBlock.toLocaleString()}
-            </Text>
-            <Text fontSize="sm" color={useColorModeValue("gray.600", "gray.400")}>•</Text>
-            <Text fontSize="sm" color={useColorModeValue("gray.600", "gray.400")}>
-              Epoch: {currentEpoch.toLocaleString()}
-            </Text>
-          </HStack>
-          
-          <Box width="100%" bg={useColorModeValue("gray.50", "gray.800")} p={4} borderRadius="md" border="1px solid" borderColor={useColorModeValue("gray.200", "gray.700")}>
-            {viewMode === "slots" ? renderSlotsView() : renderEpochsView()}
-          </Box>
         </VStack>
       ) : isUpgradeLive || slotsRemaining <= 0 ? (
         <VStack spacing={4}>


### PR DESCRIPTION
This pull request introduces two main groups of changes: (1) updates to the `/about` route and its usage throughout the application to standardize it as `/About`, and (2) improvements to the FUSAKA network upgrade countdown and the GitHub Analytics CSV download functionality. These changes enhance consistency, provide more accurate upgrade information, and improve user experience and error handling.

**Route Standardization and Navigation Updates**

* Updated all references to the `/about` route and related navigation, sidebar configuration, and resource links to use `/About`, ensuring consistent routing and case sensitivity across the app. [[1]](diffhunk://#diff-3c67eb27b539c61276d7c7cbcdbe15d4b37a6cbf58bf8bc12c1c4d7619c96d1cR18-R22) [[2]](diffhunk://#diff-0dce242c6c493ad784b03374bef9541bc63a42693fdb79e88c6dda5e76fbac04L174-R174) [[3]](diffhunk://#diff-afe8c1b3b0912b4478107bce5ce7cdbdf9d222b2b8e8dc902e9e593dbc985470L186-R186) [[4]](diffhunk://#diff-806fb263bffcf02eb8231b58ba10e24177add32bdfeba4ccfcd19f257e69cf35L245-R245) [[5]](diffhunk://#diff-96e5cf2085401461b17f519ea7b7a7670e97a7bef9ae0cef58e913fae65857e0L41-R41) [[6]](diffhunk://#diff-96e5cf2085401461b17f519ea7b7a7670e97a7bef9ae0cef58e913fae65857e0L74-R74)

**FUSAKA Network Upgrade Countdown Improvements**

* Set the mainnet as the default network for the countdown, updated FUSAKA upgrade details (activation block, epoch, features, and mainnet date), and improved color schemes and badge labels for mainnet/testnet selection. [[1]](diffhunk://#diff-4a1f4a7328bf1b42bb3090bf004e5a82bb20fbad322c57de2eed97efa272c229L64-R85) [[2]](diffhunk://#diff-4a1f4a7328bf1b42bb3090bf004e5a82bb20fbad322c57de2eed97efa272c229R104) [[3]](diffhunk://#diff-4a1f4a7328bf1b42bb3090bf004e5a82bb20fbad322c57de2eed97efa272c229L111-R113) [[4]](diffhunk://#diff-4a1f4a7328bf1b42bb3090bf004e5a82bb20fbad322c57de2eed97efa272c229L745-R748) [[5]](diffhunk://#diff-4a1f4a7328bf1b42bb3090bf004e5a82bb20fbad322c57de2eed97efa272c229L771-R773) [[6]](diffhunk://#diff-4a1f4a7328bf1b42bb3090bf004e5a82bb20fbad322c57de2eed97efa272c229L780-R782)
* Removed outdated "TBD" mainnet messaging and replaced it with the actual upgrade date and more informative badges in the countdown UI.

**GitHub Analytics CSV Download Enhancements**

* Added checks to ensure users select at least one category before downloading, and that data is loaded before allowing download, with clear alert messages for missing selections or incomplete data. [[1]](diffhunk://#diff-798b4bd653f67f44aa5ec2e95c2826f28cb8f443c611320d050fd092bfd3349bR1187-R1193) [[2]](diffhunk://#diff-798b4bd653f67f44aa5ec2e95c2826f28cb8f443c611320d050fd092bfd3349bR1213-R1220)
* Improved feedback when no data is available for the selected categories, including more descriptive alerts and logging.
* Enhanced the download button UI to display a loading spinner and update the tooltip/title while data is loading, improving user experience during CSV export. [[1]](diffhunk://#diff-798b4bd653f67f44aa5ec2e95c2826f28cb8f443c611320d050fd092bfd3349bL1769-R1790) [[2]](diffhunk://#diff-798b4bd653f67f44aa5ec2e95c2826f28cb8f443c611320d050fd092bfd3349bL1788-R1817)…d update Fusaka mainnet configuration

- Changed all '/about' references to '/About' in Footer.tsx, Resources2.tsx, Resources3.tsx, and slidebarConfig.ts
- Added middleware redirect for lowercase '/about' to '/About' for consistent routing
- Updated SlotCountdown.tsx with Fusaka mainnet activation details (block 13164544, epoch 411454, December 4, 2025)
- Enhanced Fusaka upgrade description with PeerDAS and increased gas limit features