### PR TITLE
refactor: change PM2 reload to use process name instead of numeric ID

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,7 +91,7 @@ jobs:
             mv $TEMP_DIR/.next .next
 
             # Reload PM2 gracefully
-            if ! pm2 reload 39; then
+            if ! pm2 reload eip-client; then
               echo "⚠️ PM2 reload failed, trying to start..."
               pm2 start npm --name "eips-insight" -- start
             fi


### PR DESCRIPTION
- Changed PM2 reload command from numeric ID (39) to process name (eip-client) in deploy.yml
- Improves maintainability by using descriptive process name instead of hardcoded ID