### PR TITLE
Added a custom polyfill for `structuredClone` in `src/lib/polyfills.ts`, providing deep cloning support for most object types in environments where this function is not natively available.

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,3 +1,4 @@
+import './polyfills'; // Load polyfills for older Node.js versions
 import { supabaseAdmin } from './supabase';
 import bcrypt from 'bcryptjs';
 import { SignJWT, jwtVerify } from 'jose';

--- a/src/lib/polyfills.ts
+++ b/src/lib/polyfills.ts
@@ -1,0 +1,38 @@
+// Polyfill for structuredClone (Node.js < v17)
+// This is needed for production environments running older Node.js versions
+
+if (typeof global.structuredClone !== 'function') {
+  global.structuredClone = function structuredClone(value: any): any {
+    // Simple deep clone implementation
+    // For complex objects, this handles most cases
+    if (value === null || typeof value !== 'object') {
+      return value;
+    }
+
+    // Handle Date
+    if (value instanceof Date) {
+      return new Date(value.getTime());
+    }
+
+    // Handle Array
+    if (Array.isArray(value)) {
+      return value.map((item) => structuredClone(item));
+    }
+
+    // Handle Object
+    if (value instanceof Object) {
+      const clonedObj: any = {};
+      for (const key in value) {
+        if (Object.prototype.hasOwnProperty.call(value, key)) {
+          clonedObj[key] = structuredClone(value[key]);
+        }
+      }
+      return clonedObj;
+    }
+
+    // Fallback for other types
+    return value;
+  };
+}
+
+export {};


### PR DESCRIPTION
This pull request introduces a polyfill for the `structuredClone` function to ensure compatibility with older Node.js versions, and loads it automatically in the authentication library. These changes help prevent runtime errors in production environments that use Node.js versions prior to v17.

**Node.js compatibility improvements:**

* Added a custom polyfill for `structuredClone` in `src/lib/polyfills.ts`, providing deep cloning support for most object types in environments where this function is not natively available.
* Updated `src/lib/auth.ts` to import the new polyfills, ensuring that `structuredClone` is available before any authentication logic runs.