### PR TITLE
feat: remove month filtering from PR labels chart visualization while…

### DIFF
--- a/src/components/PrLabelsChart.tsx
+++ b/src/components/PrLabelsChart.tsx
@@ -264,12 +264,9 @@ const EipsLabelChart = () => {
   const renderChart = () => {
       if (!Array?.isArray(chartData)) return null;
   
-      // Filter chartData by selectedMonth if a month is selected
-      const filteredChartData = selectedMonth 
-        ? chartData.filter(item => item.monthYear === selectedMonth)
-        : chartData;
-  
-      const transformedData = filteredChartData?.reduce<{
+      // Chart shows ALL timeline data (not filtered by selectedMonth)
+      // The selectedMonth is only used for CSV downloads
+      const transformedData = chartData?.reduce<{
         [key: string]: { [key: string]: number };
       }>((acc, { monthYear, label, count }) => {
         // Determine the actual label to use
@@ -291,7 +288,7 @@ const EipsLabelChart = () => {
         return acc;
       }, {});
 
-      console.log("transformed data for selected month:",transformedData);
+      console.log("transformed data (full timeline):",transformedData);
   
       // Convert to array format for the chart
       const finalData = Object?.keys(transformedData).flatMap(monthYear => {


### PR DESCRIPTION
This pull request updates the chart rendering logic in `PrLabelsChart.tsx` to ensure that the chart always displays data for the full timeline, regardless of the selected month. The selected month is now only used for CSV downloads, not for filtering the chart. The console log message is also updated to reflect this change.

Chart data handling:

* The chart now displays all timeline data and is no longer filtered by `selectedMonth`; filtering by month is only used for CSV downloads. (`src/components/PrLabelsChart.tsx`)

Developer experience:

* Updated the console log message to clarify that the transformed data represents the full timeline, not just the selected month. (`src/components/PrLabelsChart.tsx`)… preserving CSV export functionality

- Removed selectedMonth filtering from chart rendering to display full timeline data
- Updated chart to show all months regardless of selectedMonth selection
- Kept selectedMonth filter only for CSV export functionality
- Updated console log message to reflect that chart displays full timeline data