### PR TITLE
feat: change default view mode from epochs to slots and adjust epoch …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -152,6 +152,7 @@
         "xlsx": "^0.18.5"
       },
       "devDependencies": {
+        "@types/canvas-confetti": "^1.9.0",
         "@types/d3": "^7.4.3",
         "@types/express": "^4.17.17",
         "@types/file-saver": "^2.0.7",
@@ -10354,6 +10355,13 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@types/btoa-lite/-/btoa-lite-1.0.2.tgz",
       "integrity": "sha512-ZYbcE2x7yrvNFJiU7xJGrpF/ihpkM7zKgw8bha3LNJSesvTtUNxbpzaT7WXBIryf6jovisrxTBvymxMeLLj1Mg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/canvas-confetti": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@types/canvas-confetti/-/canvas-confetti-1.9.0.tgz",
+      "integrity": "sha512-aBGj/dULrimR1XDZLtG9JwxX1b4HPRF6CX9Yfwh3NvstZEm1ZL7RBnel4keCPSqs1ANRu1u2Aoz9R+VmtjYuTg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/connect": {

--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
     "xlsx": "^0.18.5"
   },
   "devDependencies": {
+    "@types/canvas-confetti": "^1.9.0",
     "@types/d3": "^7.4.3",
     "@types/express": "^4.17.17",
     "@types/file-saver": "^2.0.7",

--- a/src/components/SlotCountdown.tsx
+++ b/src/components/SlotCountdown.tsx
@@ -130,7 +130,7 @@ const SlotCountdown: React.FC = () => {
   const [loading, setLoading] = useState<boolean>(true);
   const [countdown, setCountdown] = useState<string>("");
   const [isUpgradeLive, setIsUpgradeLive] = useState<boolean>(false);
-  const [viewMode, setViewMode] = useState<"slots" | "epochs">("epochs");
+  const [viewMode, setViewMode] = useState<"slots" | "epochs">("slots");
   const [showInfo, setShowInfo] = useState<boolean>(false);
   const [mergedNetworks, setMergedNetworks] = useState<Set<string>>(new Set());
   const { isOpen: isCelebrationOpen, onOpen: onCelebrationOpen, onClose: onCelebrationClose } = useDisclosure();
@@ -745,7 +745,7 @@ Testing complete, ready for mainnet! 🎯
         </Text>
         
         <VStack spacing={2}>
-          <HStack spacing={2} wrap="wrap" justify="center" px={2}>
+          <HStack spacing={2} wrap="wrap" justify="center">
             {epochs.slice(0, 8).map((epoch) => {
               const isCurrent = epoch === currentEpoch;
               const isTarget = epoch === networks[network].targetepoch;
@@ -835,7 +835,7 @@ Testing complete, ready for mainnet! 🎯
             
           </HStack>
           
-          <HStack spacing={2} wrap="wrap" justify="center" px={2}>
+          <HStack spacing={2} wrap="wrap" justify="center">
             {epochs.slice(8).map((epoch) => {
               const isCurrent = epoch === currentEpoch;
               const isTarget = epoch === networks[network].targetepoch;
@@ -1073,8 +1073,8 @@ Testing complete, ready for mainnet! 🎯
           width="120px"
           size="sm"
         >
-          <option value="epochs">Epochs</option>
           <option value="slots">Slots</option>
+          <option value="epochs">Epochs</option>
         </Select>
       </Flex>
 


### PR DESCRIPTION
This pull request introduces a minor dependency update and adjusts the default view mode and some layout details in the `SlotCountdown` component. The most important changes focus on improving the user interface and developer experience.

**UI/UX Improvements:**

* Changed the default value of `viewMode` in `SlotCountdown.tsx` from `"epochs"` to `"slots"` to make slots the initial view for users.
* Adjusted layout by removing unnecessary horizontal padding (`px={2}`) from two `HStack` components, ensuring more consistent alignment. [[1]](diffhunk://#diff-4a1f4a7328bf1b42bb3090bf004e5a82bb20fbad322c57de2eed97efa272c229L748-R748) [[2]](diffhunk://#diff-4a1f4a7328bf1b42bb3090bf004e5a82bb20fbad322c57de2eed97efa272c229L838-R838)
* Reordered the options in the `Select` dropdown so that `"slots"` appears before `"epochs"`, matching the new default view mode.

**Dependency Update:**

* Added `@types/canvas-confetti` to `devDependencies` in `package.json` for improved type safety when using the `canvas-confetti` library.