### PR TITLE
Updated the FUSAKA schedule labels in `FUSAKA_INFO.schedule`

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -532,13 +532,13 @@ const linkColor = useColorModeValue("blue.600", "blue.300");
                           </Box>
 
                           {/* Fusaka Countdown Badge - Enhanced */}
-                          <Box
+                          {/* <Box
                             as={motion.div}
                             whileHover={{ scale: 1.02 }}
                             transition={{ type: "spring", stiffness: 400, damping: 17 } as any}
                           >
                             <FusakaCountdownBadge variant="compact" />
-                          </Box>
+                          </Box> */}
                         </Stack>
 
                         {/* Enhanced Dropdown */}
@@ -702,9 +702,9 @@ const linkColor = useColorModeValue("blue.600", "blue.300");
                   </Stack>
                   
                   {/* Fusaka Countdown Badge - Mobile */}
-                  <Box mt={6} display="flex" justifyContent="center">
+                  {/* <Box mt={6} display="flex" justifyContent="center">
                     <FusakaCountdownBadge variant="detailed" />
-                  </Box>
+                  </Box> */}
                   
                   <div className="mt-6">
                     <AllChart type="Total" dataset={data} />

--- a/src/components/SlotCountdown.tsx
+++ b/src/components/SlotCountdown.tsx
@@ -95,10 +95,10 @@ const FUSAKA_INFO = {
     "secp256r1 Precompile: Native support for modern secure hardware (EIP-7951)"
   ],
   schedule: {
-    holesky: "October 1, 2025 - 08:48 UTC ✅ MERGED",
-    sepolia: "October 14, 2025 - 07:36 UTC ✅ MERGED",
-    hoodi: "October 28, 2025 - 18:53 UTC ✅ MERGED",
-    mainnet: "December 3, 2025 - 21:49:11 UTC 🚀",
+    holesky: "October 1, 2025 - 08:48 UTC ✅",
+    sepolia: "October 14, 2025 - 07:36 UTC ✅",
+    hoodi: "October 28, 2025 - 18:53 UTC ✅",
+    mainnet: "December 3, 2025 - 21:49:11 UTC ✅",
   },
   readMore: {
     label: "Read more about FUSAKA",
@@ -312,7 +312,7 @@ Testing complete, ready for mainnet! 🎯
       ctx.textAlign = 'center';
       ctx.textBaseline = 'middle';
       
-      const mainText = network === 'mainnet' ? 'FUSAKA IS LIVE!' : 'FUSAKA MERGED!';
+      const mainText = network === 'mainnet' ? 'FUSAKA IS LIVE!' : 'FUSAKA!';
       ctx.fillText(mainText, canvas.width / 2, canvas.height / 2 - 60);
       
       // Reset shadow for other elements
@@ -1108,10 +1108,10 @@ Testing complete, ready for mainnet! 🎯
               {net.charAt(0).toUpperCase() + net.slice(1)}
               {(net === "holesky" || net === "sepolia" || net === "hoodi") && (
                 <Badge ml={1} colorScheme="green" fontSize="9px" variant="solid">
-                  ✅ MERGED
+                  ✅ FINAL
                 </Badge>
               )}
-              {net === "mainnet" && <Badge ml={1} colorScheme="blue" fontSize="9px" variant="solid">DEC 3</Badge>}
+              {net === "mainnet" && <Badge ml={1} colorScheme="blue" fontSize="9px" variant="solid">FINAL</Badge>}
               {mergedNetworks.has(net) && (
                 <Box
                   position="absolute"

--- a/src/pages/upgrade/index.tsx
+++ b/src/pages/upgrade/index.tsx
@@ -1178,7 +1178,7 @@ const All = () => {
     setIsLoading(false);
   }, []);
   
-  const [selectedOption, setSelectedOption] = useState<'pectra' | 'fusaka' | 'glamsterdam'>('fusaka');
+  const [selectedOption, setSelectedOption] = useState<'pectra' | 'fusaka' | 'glamsterdam'>('glamsterdam');
   const { selectedUpgrade, setSelectedUpgrade } = useSidebar();
   const [recentGlamsterdamData, setRecentGlamsterdamData] = useState<any>(null);
   const [isLoadingGlamsterdamData, setIsLoadingGlamsterdamData] = useState(false);


### PR DESCRIPTION
This pull request makes several UI and data updates related to the FUSAKA upgrade status and presentation, as well as a change to the default selected upgrade in the upgrade page. The main themes are improvements to FUSAKA status messaging, badge labeling, and minor code cleanups.

**FUSAKA status and badge updates:**

* Updated the FUSAKA schedule labels in `FUSAKA_INFO.schedule` to remove "MERGED" and use only the checkmark for completed upgrades, and changed the mainnet status to use the checkmark instead of the rocket emoji for consistency.
* Changed the badge text for test networks (holesky, sepolia, hoodi) from "✅ MERGED" to "✅ FINAL", and for mainnet from "DEC 3" to "FINAL" in the slot countdown UI, clarifying the upgrade status.
* Updated the main text in the slot countdown canvas for non-mainnet networks from "FUSAKA MERGED!" to "FUSAKA!", simplifying the messaging.

**UI and code cleanup:**

* Commented out the Fusaka countdown badge components in both desktop and mobile views of the dashboard, possibly for design or redundancy reasons. [[1]](diffhunk://#diff-55f0972bb4b7296662837848de58d3f196d3d2626f9bc3002cf1f3d782952b28L535-R541) [[2]](diffhunk://#diff-55f0972bb4b7296662837848de58d3f196d3d2626f9bc3002cf1f3d782952b28L705-R707)

**Default upgrade selection change:**

* Changed the default selected upgrade in the upgrade page from "fusaka" to "glamsterdam", affecting which upgrade is shown by default to users.