### PR TITLE
feat: add Fusaka network upgrade to NetworkUpgradesChart with 13 EIPs

### DIFF
--- a/src/components/NetworkUpgradesChart.tsx
+++ b/src/components/NetworkUpgradesChart.tsx
@@ -22,6 +22,7 @@ interface UpgradeData {
 
 
 const professionalColorMap: Record<string, string> = {
+  "Fusaka": "#10B981",            // Emerald 500 (2025-12-03)
   "Pectra": "#DC2626",            // Red 600 (2025-05-07)
   "Dencun": "#2563EB",            // Blue 600 (2024-03-13)
   "Shanghai": "#059669",          // Emerald 600 (2023-04-12)
@@ -49,6 +50,21 @@ const professionalColorMap: Record<string, string> = {
 
 // Original data set
 const rawData = [
+  // Fusaka (Fulu-Osaka) — December 3, 2025
+  { date: "2025-12-03", upgrade: "Fusaka", eip: "EIP-7594" },
+  { date: "2025-12-03", upgrade: "Fusaka", eip: "EIP-7823" },
+  { date: "2025-12-03", upgrade: "Fusaka", eip: "EIP-7825" },
+  { date: "2025-12-03", upgrade: "Fusaka", eip: "EIP-7883" },
+  { date: "2025-12-03", upgrade: "Fusaka", eip: "EIP-7892" },
+  { date: "2025-12-03", upgrade: "Fusaka", eip: "EIP-7910" },
+  { date: "2025-12-03", upgrade: "Fusaka", eip: "EIP-7917" },
+  { date: "2025-12-03", upgrade: "Fusaka", eip: "EIP-7918" },
+  { date: "2025-12-03", upgrade: "Fusaka", eip: "EIP-7934" },
+  { date: "2025-12-03", upgrade: "Fusaka", eip: "EIP-7935" },
+  { date: "2025-12-03", upgrade: "Fusaka", eip: "EIP-7939" },
+  { date: "2025-12-03", upgrade: "Fusaka", eip: "EIP-7951" },
+  { date: "2025-12-03", upgrade: "Fusaka", eip: "EIP-7642" },
+
   // Pectra (Prague-Electra) — May 7, 2025
   { date: "2025-05-07", upgrade: "Pectra", eip: "EIP-2537" },
   { date: "2025-05-07", upgrade: "Pectra", eip: "EIP-2935" },


### PR DESCRIPTION
This pull request updates the `NetworkUpgradesChart` component to include information about the upcoming "Fusaka" network upgrade. The changes add "Fusaka" to the color mapping and introduce a set of EIPs associated with this upgrade to the data set.

Network upgrade data additions:

* Added "Fusaka" (Fulu-Osaka, scheduled for 2025-12-03) to the `professionalColorMap` with its own color for chart representation.
* Appended multiple EIPs related to the "Fusaka" upgrade to the `rawData` array, ensuring they will be displayed in the chart for the correct date and upgrade.