### PR TITLE
fix: use html_url instead of url for PR review activity metadata

### DIFF
--- a/src/services/ContributorSyncService.ts
+++ b/src/services/ContributorSyncService.ts
@@ -548,7 +548,7 @@ export class ContributorSyncService {
             entityRef,
             timestamp: new Date(review.submitted_at || new Date()),
             metadata: {
-              url: review.url || review.html_url,
+              url: review.html_url,
               htmlUrl: review.html_url,
               number: pr.number,
               repositoryFullName: repository,


### PR DESCRIPTION
This pull request makes a minor update to the way review URLs are handled in the `ContributorSyncService`. The `url` field in the review metadata is now consistently set to `review.html_url`, ensuring the correct URL format is used.