### PR TITLE
fix: change database name from eipsinsight-contributors to test acros…

### DIFF
--- a/src/pages/api/contributors/list.ts
+++ b/src/pages/api/contributors/list.ts
@@ -25,7 +25,7 @@ export default async function handler(
     const offset = (pageNum - 1) * limitNum;
 
     const client = await clientPromise;
-    const db = client.db("eipsinsight-contributors");
+    const db = client.db("test");
 
     const filter: any = { isBot: false };
 

--- a/src/pages/api/contributors/stats.ts
+++ b/src/pages/api/contributors/stats.ts
@@ -33,7 +33,7 @@ export default async function handler(
 
   try {
     const client = await clientPromise;
-    const db = client.db("eipsinsight-contributors");
+    const db = client.db("test");
 
     const now = new Date();
     const last24h = new Date(now.getTime() - 24 * 60 * 60 * 1000);

--- a/src/pages/api/contributors/sync-status.ts
+++ b/src/pages/api/contributors/sync-status.ts
@@ -21,7 +21,7 @@ export default async function handler(
 
   try {
     const client = await clientPromise;
-    const db = client.db("eipsinsight-contributors");
+    const db = client.db("test");
 
     const syncStates = await db
       .collection("sync_state")

--- a/src/pages/api/contributors/timeline.ts
+++ b/src/pages/api/contributors/timeline.ts
@@ -30,7 +30,7 @@ export default async function handler(
     const offset = (pageNum - 1) * limitNum;
 
     const client = await clientPromise;
-    const db = client.db("eipsinsight-contributors");
+    const db = client.db("test");
 
     const filter: any = { username };
 

--- a/src/pages/api/cron/sync-contributors.ts
+++ b/src/pages/api/cron/sync-contributors.ts
@@ -75,7 +75,7 @@ export default async function handler(
     await syncService.updateActivityTimestamps();
 
     const client = await clientPromise;
-    const db = client.db("eipsinsight-contributors");
+    const db = client.db("test");
 
     const totalContributors = await db
       .collection("contributors")

--- a/src/services/ContributorSyncService.ts
+++ b/src/services/ContributorSyncService.ts
@@ -66,7 +66,7 @@ export class ContributorSyncService {
   private async getDb(): Promise<Db> {
     if (!this.db) {
       const client = await clientPromise;
-      this.db = client.db("eipsinsight-contributors");
+      this.db = client.db("test");
     }
     return this.db;
   }


### PR DESCRIPTION
This pull request updates the database configuration across several API endpoints and a service. The main change is switching the MongoDB database name from `"eipsinsight-contributors"` to `"test"` in all relevant locations. This likely supports development or testing workflows by redirecting all data operations to a test database.

**Database configuration changes:**

* Changed the database name from `"eipsinsight-contributors"` to `"test"` in the following API route handlers: `contributors/list.ts`, `contributors/stats.ts`, `contributors/sync-status.ts`, `contributors/timeline.ts`, and `cron/sync-contributors.ts`. [[1]](diffhunk://#diff-b2140e14ddec7a6611c4f42eb355cd9a2012ef25019addc18928f95a12ab480bL28-R28) [[2]](diffhunk://#diff-051847211215939eea21fdc6ffd9954af94a6204c2f1790b8805ff4d9b6c7322L36-R36) [[3]](diffhunk://#diff-f505f7369832fa49725ca89116a8abdf5486577ac88d8e9d536faca8e7f16736L24-R24) [[4]](diffhunk://#diff-b461e76ab076d9a3697191d04a25004efd247dc1aa45c34f35e8d537ad544143L33-R33) [[5]](diffhunk://#diff-7f51402eb8a5f20a33c1b082b2b49fbfb9049a156d36354c366e0a5d2b44d03fL78-R78)
* Updated the `ContributorSyncService` to use the `"test"` database instead of `"eipsinsight-contributors"`.