### PR TITLE
fix: upgrade TypeScript compilation target from es2017 to es2022

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2017",
+    "target": "es2022",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
- Updated target in tsconfig.json to es2022 for better modern JavaScript feature support
- Added trailing newline to tsconfig.json for consistency