### PR TITLE
feat: add contributor-specific last sync time component and API endpoint

### DIFF
--- a/src/components/ContributorLastUpdatedDateTime.tsx
+++ b/src/components/ContributorLastUpdatedDateTime.tsx
@@ -1,0 +1,105 @@
+import React, { useEffect, useState } from 'react';
+import { useColorModeValue } from '@chakra-ui/react';
+
+interface ContributorLastUpdatedDateTimeProps {
+  name: string;
+}
+
+interface SyncData {
+  lastSyncAt: string;
+  totalActivities: number;
+  repositories: {
+    repository: string;
+    lastSyncAt: string;
+    activitiesProcessed: number;
+    status: string;
+  }[];
+}
+
+const ContributorLastUpdatedDateTime: React.FC<ContributorLastUpdatedDateTimeProps> = ({ name }) => {
+  const [syncData, setSyncData] = useState<SyncData | null>(null);
+  const [nextUpdateTime, setNextUpdateTime] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const textColor = useColorModeValue('#6B7280', '#9CA3AF');
+
+  useEffect(() => {
+    const fetchSyncStatus = async () => {
+      try {
+        const response = await fetch('/api/contributors/lastSyncTime');
+        if (!response.ok) {
+          throw new Error('Failed to fetch sync status');
+        }
+        const data = await response.json();
+        setSyncData(data);
+        
+        // Calculate next update time (24 hours from last sync)
+        if (data.lastSyncAt) {
+          const lastSync = new Date(data.lastSyncAt);
+          const nextUpdate = new Date(lastSync.getTime() + 24 * 60 * 60 * 1000);
+          setNextUpdateTime(nextUpdate.toISOString());
+        }
+        
+      } catch (err: any) {
+        setError(err.message);
+      }
+    };
+
+    fetchSyncStatus();
+
+    // Refresh every 1 minute to keep countdown accurate
+    const intervalId = setInterval(fetchSyncStatus, 60 * 1000);
+
+    return () => clearInterval(intervalId);
+  }, []);
+
+  if (error) {
+    return (
+      <div className='flex justify-between mx-12 lg:text-[14px] text-xs py-4 bottom-0'>
+        <div>
+          <p className='px-3 rounded-[0.55rem] py-1' style={{ color: textColor }}>EIPsInsight.com</p>
+        </div>
+        <div className='px-3 rounded-[0.55rem] py-1' style={{ color: textColor }}>
+          <p>Error loading sync status</p>
+        </div>
+      </div>
+    );
+  }
+
+  const formatDateTime = (isoString: string) => {
+    const date = new Date(isoString);
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    
+    let hours = date.getHours();
+    const ampm = hours >= 12 ? 'PM' : 'AM';
+    hours = hours % 12;
+    hours = hours ? hours : 12;
+    const hoursStr = String(hours).padStart(2, '0');
+    const minutes = String(date.getMinutes()).padStart(2, '0');
+    
+    return `${day}-${month}-${year} ${hoursStr}:${minutes} ${ampm}`;
+  };
+
+  return (
+    <>
+      <div className='flex justify-between mx-12 lg:text-[14px] text-xs py-4 bottom-0'>
+        <div>
+          <p className='px-3 rounded-[0.55rem] py-1' style={{ color: textColor }}>
+            EIPsInsight.com
+          </p>
+        </div>
+        <div className='px-3 rounded-[0.55rem] py-1' style={{ color: textColor }}>
+          {nextUpdateTime ? (
+            <p>Next Update: {formatDateTime(nextUpdateTime)}</p>
+          ) : (
+            <p>Loading...</p>
+          )}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default ContributorLastUpdatedDateTime;

--- a/src/components/contributors/ActivityComparisonChart.tsx
+++ b/src/components/contributors/ActivityComparisonChart.tsx
@@ -12,7 +12,7 @@ import {
   TooltipProps,
 } from "recharts";
 import { FiInfo, FiChevronDown, FiChevronUp } from "react-icons/fi";
-import LastUpdatedDateTime from "@/components/LastUpdatedDateTime";
+import ContributorLastUpdatedDateTime from "@/components/ContributorLastUpdatedDateTime";
 
 const CustomTooltip = ({ active, payload }: TooltipProps<number, string>) => {
   const bgColor = useColorModeValue("#FFFFFF", "#1F2937");
@@ -142,7 +142,7 @@ export const ActivityComparisonChart: React.FC<ActivityComparisonChartProps> = (
           </RadarChart>
         </ResponsiveContainer>
       </div>
-      <LastUpdatedDateTime name="Activity Comparison" />
+      <ContributorLastUpdatedDateTime name="Activity Comparison" />
     </div>
   );
 };

--- a/src/components/contributors/ActivityDistributionChart.tsx
+++ b/src/components/contributors/ActivityDistributionChart.tsx
@@ -11,7 +11,7 @@ import {
   ResponsiveContainer,
   Cell,
 } from "recharts";
-import LastUpdatedDateTime from "@/components/LastUpdatedDateTime";
+import ContributorLastUpdatedDateTime from "@/components/ContributorLastUpdatedDateTime";
 
 type ActivityType = "COMMIT" | "PR_OPENED" | "PR_MERGED" | "PR_CLOSED" | "REVIEW_APPROVED";
 
@@ -291,7 +291,7 @@ export const ActivityDistributionChart: React.FC<ActivityDistributionChartProps>
           </BarChart>
         </ResponsiveContainer>
       </div>
-      <LastUpdatedDateTime name="Activity Distribution" />
+      <ContributorLastUpdatedDateTime name="Activity Distribution" />
     </div>
   );
 };

--- a/src/components/contributors/ActivityTimelineChart.tsx
+++ b/src/components/contributors/ActivityTimelineChart.tsx
@@ -11,7 +11,7 @@ import {
   ResponsiveContainer,
   Brush,
 } from "recharts";
-import LastUpdatedDateTime from "@/components/LastUpdatedDateTime";
+import ContributorLastUpdatedDateTime from "@/components/ContributorLastUpdatedDateTime";
 
 interface ActivityTimelineChartProps {
   data: {
@@ -291,7 +291,7 @@ export const ActivityTimelineChart: React.FC<ActivityTimelineChartProps> = ({
           </AreaChart>
         </ResponsiveContainer>
       </div>
-      <LastUpdatedDateTime name="Activity Timeline" />
+      <ContributorLastUpdatedDateTime name="Activity Timeline" />
     </div>
   );
 };

--- a/src/components/contributors/ActivityVelocityChart.tsx
+++ b/src/components/contributors/ActivityVelocityChart.tsx
@@ -13,7 +13,7 @@ import {
   TooltipProps,
 } from "recharts";
 import { FiInfo, FiChevronDown, FiChevronUp } from "react-icons/fi";
-import LastUpdatedDateTime from "@/components/LastUpdatedDateTime";
+import ContributorLastUpdatedDateTime from "@/components/ContributorLastUpdatedDateTime";
 
 const CustomTooltip = ({ active, payload, label }: TooltipProps<number, string>) => {
   const bgColor = useColorModeValue("#FFFFFF", "#1F2937");
@@ -148,7 +148,7 @@ export const ActivityVelocityChart: React.FC<ActivityVelocityChartProps> = ({
           </LineChart>
         </ResponsiveContainer>
       </div>
-      <LastUpdatedDateTime name="Activity Velocity" />
+      <ContributorLastUpdatedDateTime name="Activity Velocity" />
     </div>
   );
 };

--- a/src/components/contributors/AllTimeChart.tsx
+++ b/src/components/contributors/AllTimeChart.tsx
@@ -10,7 +10,7 @@ import {
   Legend,
   ResponsiveContainer,
 } from "recharts";
-import LastUpdatedDateTime from "@/components/LastUpdatedDateTime";
+import ContributorLastUpdatedDateTime from "@/components/ContributorLastUpdatedDateTime";
 
 interface AllTimeChartProps {
   data: {
@@ -151,7 +151,7 @@ export const AllTimeChart: React.FC<AllTimeChartProps> = ({ data }) => {
           </LineChart>
         </ResponsiveContainer>
       </div>
-      <LastUpdatedDateTime name="All-Time Activity" />
+      <ContributorLastUpdatedDateTime name="All-Time Activity" />
     </div>
   );
 };

--- a/src/components/contributors/RepositoryBreakdownChart.tsx
+++ b/src/components/contributors/RepositoryBreakdownChart.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useColorModeValue } from '@chakra-ui/react';
 import { PieChart, Pie, Cell, ResponsiveContainer, Legend, Tooltip } from "recharts";
-import LastUpdatedDateTime from "@/components/LastUpdatedDateTime";
+import ContributorLastUpdatedDateTime from "@/components/ContributorLastUpdatedDateTime";
 
 interface RepositoryBreakdownChartProps {
   data: {
@@ -135,7 +135,7 @@ const RepositoryBreakdownChart: React.FC<RepositoryBreakdownChartProps> = ({
           </div>
         </div>
       </div>
-      <LastUpdatedDateTime name="Repository Breakdown" />
+      <ContributorLastUpdatedDateTime name="Repository Breakdown" />
     </div>
   );
 };

--- a/src/components/contributors/TopContributorsChart.tsx
+++ b/src/components/contributors/TopContributorsChart.tsx
@@ -12,7 +12,7 @@ import {
 } from "recharts";
 import { useRouter } from "next/router";
 import { FiInfo, FiChevronDown, FiChevronUp } from "react-icons/fi";
-import LastUpdatedDateTime from "@/components/LastUpdatedDateTime";
+import ContributorLastUpdatedDateTime from "@/components/ContributorLastUpdatedDateTime";
 
 interface TopContributorsChartProps {
   data: {
@@ -184,7 +184,7 @@ export const TopContributorsChart: React.FC<TopContributorsChartProps> = ({
           </BarChart>
         </ResponsiveContainer>
       </div>
-      <LastUpdatedDateTime name="Top Contributors" />
+      <ContributorLastUpdatedDateTime name="Top Contributors" />
     </div>
   );
 };

--- a/src/pages/api/contributors/lastSyncTime.ts
+++ b/src/pages/api/contributors/lastSyncTime.ts
@@ -1,0 +1,59 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import clientPromise from '@/lib/mongodb';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ message: 'Method not allowed' });
+  }
+
+  try {
+    const client = await clientPromise;
+    const db = client.db('EIPsInsight');
+    
+    // Fetch all sync_state documents
+    const syncStates = await db
+      .collection('sync_state')
+      .find({})
+      .sort({ lastSyncAt: -1 })
+      .toArray();
+
+    if (!syncStates || syncStates.length === 0) {
+      return res.status(404).json({ 
+        message: 'No sync state found',
+        lastSyncAt: null 
+      });
+    }
+
+    // Find the most recent lastSyncAt across all repositories
+    const mostRecentSync = syncStates.reduce((latest, current) => {
+      const currentTime = new Date(current.lastSyncAt).getTime();
+      const latestTime = new Date(latest.lastSyncAt).getTime();
+      return currentTime > latestTime ? current : latest;
+    }, syncStates[0]);
+
+    // Calculate total activities processed
+    const totalActivities = syncStates.reduce((sum, state) => 
+      sum + (state.activitiesProcessed || 0), 0
+    );
+
+    return res.status(200).json({
+      lastSyncAt: mostRecentSync.lastSyncAt,
+      totalActivities,
+      repositories: syncStates.map(state => ({
+        repository: state.repository,
+        lastSyncAt: state.lastSyncAt,
+        activitiesProcessed: state.activitiesProcessed,
+        status: state.status
+      }))
+    });
+  } catch (error: any) {
+    console.error('Error fetching sync state:', error);
+    return res.status(500).json({ 
+      message: 'Error fetching sync state',
+      error: error.message 
+    });
+  }
+}


### PR DESCRIPTION
This pull request introduces a new component for displaying the last updated date/time for contributor-related charts, along with a supporting API endpoint to fetch sync status from the backend. The update replaces the previous `LastUpdatedDateTime` component with the new `ContributorLastUpdatedDateTime` component across all relevant contributor chart components, ensuring a consistent and dynamic display of sync information.

Key changes include:

**New Features**

* Added the `ContributorLastUpdatedDateTime` React component, which fetches the latest contributor sync status from a new API endpoint, calculates the next update time, and displays it alongside chart components.
* Implemented the `/api/contributors/lastSyncTime` API endpoint to provide the latest sync status, including the most recent sync time, total activities processed, and per-repository sync details, by querying the MongoDB database.

**Refactoring and Integration**

* Replaced all instances of the old `LastUpdatedDateTime` component with the new `ContributorLastUpdatedDateTime` component in the following contributor chart components:
  - `ActivityComparisonChart.tsx` [[1]](diffhunk://#diff-02576ee25abe704ae52d0d23fb262928431ba66ddfbb1801663c8b429dc87205L15-R15) [[2]](diffhunk://#diff-02576ee25abe704ae52d0d23fb262928431ba66ddfbb1801663c8b429dc87205L145-R145)
  - `ActivityDistributionChart.tsx` [[1]](diffhunk://#diff-49f648418fbc1ce1fff08be8535007bee074dd686ff0d8cd81e4d3784834a0dfL14-R14) [[2]](diffhunk://#diff-49f648418fbc1ce1fff08be8535007bee074dd686ff0d8cd81e4d3784834a0dfL294-R294)
  - `ActivityTimelineChart.tsx` [[1]](diffhunk://#diff-28943ca369e53a4c010336a82881c396e978f030ea87d22fe131b98522f5e199L14-R14) [[2]](diffhunk://#diff-28943ca369e53a4c010336a82881c396e978f030ea87d22fe131b98522f5e199L294-R294)
  - `ActivityVelocityChart.tsx` [[1]](diffhunk://#diff-34eec6bdebf63e83f3431c9edf7ae09f971364bfaeaec6010344b78df441ef68L16-R16) [[2]](diffhunk://#diff-34eec6bdebf63e83f3431c9edf7ae09f971364bfaeaec6010344b78df441ef68L151-R151)
  - `AllTimeChart.tsx` [[1]](diffhunk://#diff-3adf3e12f643153d8e6048af6dbac514ee43e28445a74e6f31743ab6ad941d0aL13-R13) [[2]](diffhunk://#diff-3adf3e12f643153d8e6048af6dbac514ee43e28445a74e6f31743ab6ad941d0aL154-R154)
  - `RepositoryBreakdownChart.tsx` [[1]](diffhunk://#diff-92715200457370778d5a66efbadaf0435a464af564b1e457f4e139d990e5cf75L4-R4) [[2]](diffhunk://#diff-92715200457370778d5a66efbadaf0435a464af564b1e457f4e139d990e5cf75L138-R138)
  - `TopContributorsChart.tsx` [[1]](diffhunk://#diff-7903f3f928b2d86457afa1c4cd039c612624e935357b08065963dc16218cffc7L15-R15) [[2]](diffhunk://#diff-7903f3f928b2d86457afa1c4cd039c612624e935357b08065963dc16218cffc7L187-R187)