### PR TITLE
fix: change database name from EIPsInsight to test in contributors la…

### DIFF
--- a/src/pages/api/contributors/lastSyncTime.ts
+++ b/src/pages/api/contributors/lastSyncTime.ts
@@ -11,7 +11,7 @@ export default async function handler(
 
   try {
     const client = await clientPromise;
-    const db = client.db('EIPsInsight');
+    const db = client.db('test');
     
     // Fetch all sync_state documents
     const syncStates = await db


### PR DESCRIPTION
This pull request makes a small change to the database connection in the `src/pages/api/contributors/lastSyncTime.ts` API handler. The database used for fetching sync state documents is switched from `'EIPsInsight'` to `'test'`.