### PR TITLE
fix : Update to next update time calculation

### DIFF
--- a/src/components/ContributorLastUpdatedDateTime.tsx
+++ b/src/components/ContributorLastUpdatedDateTime.tsx
@@ -33,10 +33,10 @@ const ContributorLastUpdatedDateTime: React.FC<ContributorLastUpdatedDateTimePro
         const data = await response.json();
         setSyncData(data);
         
-        // Calculate next update time (24 hours from last sync)
+        // Calculate next update time (4 hours from last sync)
         if (data.lastSyncAt) {
           const lastSync = new Date(data.lastSyncAt);
-          const nextUpdate = new Date(lastSync.getTime() + 24 * 60 * 60 * 1000);
+          const nextUpdate = new Date(lastSync.getTime() + 4 * 60 * 60 * 1000);
           setNextUpdateTime(nextUpdate.toISOString());
         }
         

--- a/src/components/LastUpdatedDateTime.tsx
+++ b/src/components/LastUpdatedDateTime.tsx
@@ -19,9 +19,9 @@ const LastUpdatedDateTime: React.FC<DateTimeProps> = ({ name }) => {
         const data = await response.json();
         setLastUpdatedTime(data.lastUpdatedTime);
         
-        // Calculate next update time (5 minutes from now)
-        const now = new Date();
-        const nextUpdate = new Date(now.getTime() + 5 * 60 * 1000);
+        // Calculate next update time (4 hours from last update)
+        const lastUpdate = new Date(data.lastUpdatedTime);
+        const nextUpdate = new Date(lastUpdate.getTime() + 4 * 60 * 60 * 1000);
         setNextUpdateTime(nextUpdate.toISOString());
         
       } catch (err:any) {


### PR DESCRIPTION
This pull request updates the logic for calculating the "next update time" in both the `ContributorLastUpdatedDateTime` and `LastUpdatedDateTime` components to ensure consistency and accuracy. The next update time is now consistently set to 4 hours after the last sync or update, instead of the previous intervals.

**Update to next update time calculation:**

- Changed the next update time in `ContributorLastUpdatedDateTime.tsx` to be 4 hours after the last sync, instead of 24 hours.
- Changed the next update time in `LastUpdatedDateTime.tsx` to be 4 hours after the last update, instead of 5 minutes from the current time.