### PR TITLE
refactor: migrate blog post images from private GitHub URLs to public…

### DIFF
--- a/src/blogs/glamsterdam-scope-narrows-core-devs-confirm-cfi-dfi.md
+++ b/src/blogs/glamsterdam-scope-narrows-core-devs-confirm-cfi-dfi.md
@@ -8,7 +8,7 @@ tags: ["Ethereum", "Glamsterdam", "CFI", "DFI", "Core Devs", "Governance", "Prot
 readTime: 5
 featured: true
 excerpt: "Ethereum core developers have narrowed the Glamsterdam upgrade scope by designating key proposals as CFI or DFI, providing clearer direction for client teams and aligning Ethereum’s next major upgrade toward manageable and high-impact priorities."
-image: "https://private-user-images.githubusercontent.com/69413160/524271577-56da3e42-9467-4911-af9b-30c80042973d.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NjY2ODU3ODAsIm5iZiI6MTc2NjY4NTQ4MCwicGF0aCI6Ii82OTQxMzE2MC81MjQyNzE1NzctNTZkYTNlNDItOTQ2Ny00OTExLWFmOWItMzBjODAwNDI5NzNkLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTEyMjUlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUxMjI1VDE3NTgwMFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTlhODBhMWJjNDY3Yjk3ZGJhZjM4OWUwNzUzMjI3OGNmNjYzMmJjMzk1ZDI3OGJhNzM4YzRjNjgwY2QzOGM1MWYmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.GKISguq2gTz7U3qslo_E6idfXTixq7_xoCkM9QDeHGY"
+image: "https://raw.githubusercontent.com/AvarchLLC/EIPsInsight/refs/heads/main/public/blogs/glamsterdam-scope.png"
 authorAvatar: "https://etherworld.co/content/images/size/w300/2022/05/IMG.jpg"
 authorBio: "Blockchain Content & Ops Specialist, Avarch LLC"
 authorTwitter: "https://x.com/YashKamalChatu1"

--- a/src/blogs/timeline-for-heke-bogota.md
+++ b/src/blogs/timeline-for-heke-bogota.md
@@ -7,7 +7,7 @@ tags: ["Ethereum", "Heka", "Bogotá", "EIP-8081", "Core Devs", "Governance", "Ro
 readTime: 5
 featured: true
 excerpt: "Ethereum core developers introduce a tentative scoping timeline for the Heka/Bogotá upgrade via EIP-8081, outlining how headliners will be selected, when proposals will be evaluated, and how upgrade decisions will be finalized."
-image: "https://private-user-images.githubusercontent.com/69413160/526356313-e39e0c5a-586b-4d20-bae7-f070a3cbab79.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NjY2ODQ4ODAsIm5iZiI6MTc2NjY4NDU4MCwicGF0aCI6Ii82OTQxMzE2MC81MjYzNTYzMTMtZTM5ZTBjNWEtNTg2Yi00ZDIwLWJhZTctZjA3MGEzY2JhYjc5LnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTEyMjUlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUxMjI1VDE3NDMwMFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTlkY2ZhMmQ5Y2RhOTQxYTYzODYxNDY1YWIxNmQxNjZjOWUxOTdmNWFmM2VmN2UzOTdmZWU1MzllZThhMjRlODImWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.jf3Yok3BmsQZ5mVCGjpS0QTN7uOH1dE6D4El5Oi9rGQ"
+image: "https://raw.githubusercontent.com/AvarchLLC/EIPsInsight/refs/heads/main/public/blogs/tentative-scoping.png"
 authorAvatar: "https://etherworld.co/content/images/size/w300/2022/05/IMG.jpg"
 authorBio: "Blockchain Content & Ops Specialist, Avarch LLC"
 authorTwitter: "https://x.com/YashKamalChatu1"

--- a/src/blogs/why-ethereum-core-devs-removed-focil-from-glamsterdam-upgrade.md
+++ b/src/blogs/why-ethereum-core-devs-removed-focil-from-glamsterdam-upgrade.md
@@ -8,7 +8,7 @@ tags: ["Ethereum", "Glamsterdam", "FOCIL", "Censorship Resistance", "Governance"
 readTime: 6
 featured: true
 excerpt: "Ethereum core developers confirmed that FOCIL will not ship in the Glamsterdam upgrade, not due to technical failure but because of Ethereum’s evolving governance model, prioritizing process discipline and predictable upgrade cycles."
-image: "https://private-user-images.githubusercontent.com/69413160/528232247-f3aa23af-39c5-48d5-aa42-df84b70d0437.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NjY2ODU5MjUsIm5iZiI6MTc2NjY4NTYyNSwicGF0aCI6Ii82OTQxMzE2MC81MjgyMzIyNDctZjNhYTIzYWYtMzljNS00OGQ1LWFhNDItZGY4NGI3MGQwNDM3LnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTEyMjUlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUxMjI1VDE4MDAyNVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTU3NzNmMDU2OTgxNzdlMDBiYTNhOWZkN2ZlZTM4MmRjM2I1Yzg1OTAyNGVkNDViYjYwNzY1ZDYwZDY1ZGFkMWMmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.kWSWP2i7qq0bF1FKXJwSBWytW-b2vRS9kuev6AJKRMc"
+image: "https://raw.githubusercontent.com/AvarchLLC/EIPsInsight/refs/heads/main/public/blogs/why-ethereum-core.png"
 authorAvatar: "https://etherworld.co/content/images/size/w300/2022/05/IMG.jpg"
 authorBio: "Blockchain Content & Ops Specialist, Avarch LLC"
 authorTwitter: "https://x.com/YashKamalChatu1"


### PR DESCRIPTION
This pull request updates the blog post images for three Ethereum-related articles to use direct links from the project's GitHub repository instead of private user image links. This change ensures that the images are reliably accessible and not dependent on third-party authentication or expiring tokens.

**Blog image source updates:**

* Updated the `image` field in `src/blogs/glamsterdam-scope-narrows-core-devs-confirm-cfi-dfi.md` to use a public GitHub-hosted image link.
* Updated the `image` field in `src/blogs/timeline-for-heke-bogota.md` to use a public GitHub-hosted image link.
* Updated the `image` field in `src/blogs/why-ethereum-core-devs-removed-focil-from-glamsterdam-upgrade.md` to use a public GitHub-hosted image link.