### PR TITLE
Fix RSS feed link fallback

### DIFF
--- a/src/utils/rss.ts
+++ b/src/utils/rss.ts
@@ -41,13 +41,16 @@ export function generateRSSFeed({ title, items, id, link }: GenerateFeedParams) 
 
 // Added export to fix build error in sync.ts
 export function buildFeedItemsFromEvents(events: ChangeEvent[], baseLink: string): FeedItem[] {
-  return events.map(e => ({
-    title:
-      e.kind === 'status' && e.statusFrom && e.statusTo
-        ? `Status: ${e.statusFrom} → ${e.statusTo}`
-        : e.summary,
-    link: e.url,
-    description: e.message || e.summary,
-    date: new Date(e.date)
-  }));
+  return events.map(e => {
+    const link = e.url || baseLink;
+    return {
+      title:
+        e.kind === 'status' && e.statusFrom && e.statusTo
+          ? `Status: ${e.statusFrom} → ${e.statusTo}`
+          : e.summary,
+      link,
+      description: e.message || e.summary,
+      date: new Date(e.date)
+    };
+  });
 }


### PR DESCRIPTION
### Motivation

- RSS items were being produced with missing/undefined links when an event lacked a commit URL, resulting in broken feed entries.
- Provide a stable fallback URL (the proposal base link) so feed consumers always have a usable item link.

### Description

- Changed `buildFeedItemsFromEvents` in `src/utils/rss.ts` to compute `link = e.url || baseLink` and use that for each feed item.
- Preserves existing item fields (`title`, `description`, `date`) and only adjusts the `link` selection logic to be robust when `e.url` is absent.
- No other behavioral changes were introduced.

### Testing

- No automated tests were run as part of this change (no test suite executed locally or in CI).