### PR TITLE
Sort tx tracker blocks by block number (desc)

### DIFF
--- a/src/components/TxTracker/ethereumService.ts
+++ b/src/components/TxTracker/ethereumService.ts
@@ -143,7 +143,11 @@ export const fetchLast10Blocks = async (isSepolia: boolean = false) => {
       }
     }
   
-    return allBlocks;
+    const sortedBlocks = allBlocks.sort(
+      (a, b) => Number(b?.number ?? 0) - Number(a?.number ?? 0)
+    ); // Sorted by block number (desc)
+
+    return sortedBlocks;
   };
 
 // services/ethereumService.ts

--- a/src/pages/txtracker/index.tsx
+++ b/src/pages/txtracker/index.tsx
@@ -103,7 +103,7 @@ const EthereumV2 = () => {
       setLast10Blocks(limitedBlocks);
       
       // Process transactions from the latest block only to reduce memory usage
-      const latestBlockTxs = limitedBlocks[0]?.transactions || [];
+      const latestBlockTxs = limitedBlocks[0]?.transactions || []; // latest block after sorting by block number
       setRecentTransactions(limitArraySize(latestBlockTxs, MAX_TRANSACTION_HISTORY));
       setLoadingTxs(false);
       setLoadingBlocksTable(false);


### PR DESCRIPTION
### Motivation
- Ensure the block list returned to the UI is consistently ordered so consumers can rely on `limitedBlocks[0]` being the latest block.
- Prevent non-deterministic ordering caused by batched RPC responses and make downstream logic simpler and safer.

### Description
- Updated `fetchLast10Blocks` to sort the collected `allBlocks` array by block `number` in descending order and return the sorted array as `sortedBlocks`.
- Added a short inline comment in `src/pages/txtracker/index.tsx` next to `limitedBlocks[0]` to indicate it represents the latest block after sorting.
- Kept the sort implementation defensive by coercing `number` fields with `Number(...)` and guarding null/undefined values.

### Testing
- No automated tests were run.