### PR TITLE
Update JSDoc for fetchLast10Blocks to reflect 10-block behavior

### DIFF
--- a/src/components/TxTracker/ethereumService.ts
+++ b/src/components/TxTracker/ethereumService.ts
@@ -102,9 +102,9 @@ export const getBlockDetails = async (blockNumber: string | number, isSepolia: b
 };
 
 /**
- * Fetches the last 7200 blocks using batch requests.
+ * Fetches the last 10 blocks using batch requests.
  * @param isSepolia - Whether to use the Sepolia network.
- * @returns The last 7200 blocks.
+ * @returns The last 10 blocks.
  */
 export const fetchLast10Blocks = async (isSepolia: boolean = false) => {
     const provider = isSepolia ? sepoliaWeb3 : web3;


### PR DESCRIPTION
### Motivation
- Ensure JSDoc accurately describes the function behavior and removes the incorrect "7200" reference.
- Prevent confusion for maintainers by aligning docs with implemented logic that requests 10 blocks.
- Keep documentation consistent with the `fetchLast10Blocks` implementation.

### Description
- Updated the JSDoc comment above `fetchLast10Blocks` in `src/components/TxTracker/ethereumService.ts` to state it fetches the last 10 blocks.
- Modified the `@returns` line to reference "The last 10 blocks" instead of "7200".

### Testing
- No automated tests were run because this is a documentation-only change.