### PR TITLE
Add TOC tests and trim generated slug IDs

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test": "bash -lc 'shopt -s globstar; node --test --loader ts-node/esm tests/**/*.test.ts'",
     "create-admin": "node scripts/create-admin.mjs",
     "migrate-blogs": "node scripts/migrate-static-blogs.mjs"
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "bash -lc 'shopt -s globstar; node --test --loader ts-node/esm tests/**/*.test.ts'",
+    "test": "node --test --loader ts-node/esm \"tests/**/*.test.ts\"",
     "create-admin": "node scripts/create-admin.mjs",
     "migrate-blogs": "node scripts/migrate-static-blogs.mjs"
   },

--- a/src/utils/toc.ts
+++ b/src/utils/toc.ts
@@ -4,7 +4,10 @@ export function extractHeadingsFromMarkdown(markdown: string) {
   return headingLines.map(line => {
     const depth = line.match(/^#+/)![0].length;
     const text = line.replace(/^#+\s?/, '').trim();
-    const id = text.toLowerCase().replace(/[^\w]+/g, '-'); // Simple slugify
+    const id = text
+      .toLowerCase()
+      .replace(/[^\w]+/g, '-')
+      .replace(/^-+|-+$/g, ''); // Simple slugify
     return { depth, text, id };
   });
 }

--- a/tests/toc.test.ts
+++ b/tests/toc.test.ts
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { extractHeadingsFromMarkdown } from '../src/utils/toc';
+
+test('extracts headings depth 1–4', () => {
+  const markdown = [
+    '# Heading 1',
+    '## Heading 2',
+    '### Heading 3',
+    '#### Heading 4',
+  ].join('\n');
+
+  const headings = extractHeadingsFromMarkdown(markdown);
+
+  assert.deepEqual(headings.map(heading => heading.depth), [1, 2, 3, 4]);
+  assert.deepEqual(headings.map(heading => heading.text), [
+    'Heading 1',
+    'Heading 2',
+    'Heading 3',
+    'Heading 4',
+  ]);
+});
+
+test('ignores headings deeper than 4', () => {
+  const markdown = [
+    '# Heading 1',
+    '##### Heading 5',
+    '###### Heading 6',
+    '#### Heading 4',
+  ].join('\n');
+
+  const headings = extractHeadingsFromMarkdown(markdown);
+
+  assert.deepEqual(headings.map(heading => heading.text), ['Heading 1', 'Heading 4']);
+});
+
+test('generates a slug id from heading text', () => {
+  const markdown = '# My Heading!';
+
+  const headings = extractHeadingsFromMarkdown(markdown);
+
+  assert.equal(headings[0].id, 'my-heading');
+});


### PR DESCRIPTION
### Motivation
- Add unit coverage for the TOC extraction to verify heading parsing and slug generation.
- Prevent generated TOC `id` values from having leading or trailing hyphens for cleaner anchors.
- Provide an easy `npm` test script that runs Node's built-in test runner with TypeScript support.

### Description
- Update `src/utils/toc.ts` to trim leading/trailing hyphens in the slug by adding `.replace(/^-+|-+$/g, '')` to the slugify pipeline.
- Add `tests/toc.test.ts` which verifies parsing of headings depth 1–4, ignores headings deeper than 4, and asserts slug generation (e.g., `My Heading!` → `my-heading`).
- Add a `test` script to `package.json` that runs `node --test --loader ts-node/esm tests/**/*.test.ts` wrapped in a shell glob expansion.

### Testing
- Ran `npm test` which invoked the Node test runner via the new script but it failed with `ERR_MODULE_NOT_FOUND` because `ts-node` was not available.
- Attempted `npm install` to provision `ts-node` and other dev dependencies but the install failed due to npm registry `403` errors in this environment, so the tests could not be executed successfully.
- The test file (`tests/toc.test.ts`) and changes to `src/utils/toc.ts` were added and are ready to run in an environment where dependencies can be installed.