### PR TITLE
feat: add 2026 sub-navigation item to Insight in Navbar

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -115,6 +115,10 @@ const Navbar: React.FC = () => {
     {
       label: "Insight",
       children: [
+                {
+          label: "2026",
+          children: getMonthsTillCurrentYear(),
+        },
         {
           label: "2025",
           children: getMonthsTillCurrentYear(),


### PR DESCRIPTION
This pull request updates the `Navbar` component to add a new "2026" section under the "Insight" menu, mirroring the existing "2025" section. This ensures users can now navigate to insights for both 2025 and 2026.

- Navigation Menu Update:
  * Added a "2026" submenu under the "Insight" menu in the `Navbar`, using `getMonthsTillCurrentYear()` to populate its children.