### PR TITLE
feat: enhance NetworkUpgradesChart to handle Petersburg; update children for 2025 navigation item to reflect correct months

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -121,7 +121,7 @@ const Navbar: React.FC = () => {
         },
         {
           label: "2025",
-          children: getMonthsTillCurrentYear(),
+          children: getMonthsTillYear(2025),
         },
         {
           label: "2024",


### PR DESCRIPTION
This pull request refines the logic for grouping and displaying network upgrades in the `NetworkUpgradesChart` component, with a particular focus on handling the Petersburg and Constantinople upgrades. It also updates the way months are displayed for the year 2025 in the `Navbar` component. The main improvements ensure that upgrades sharing the same date are split into separate rows when necessary, and that upgrade names are constructed more accurately.

**Network Upgrades Chart Logic Improvements:**

* Petersburg and Constantinople upgrades that occurred on the same date are now split into separate rows, ensuring clearer representation and more accurate EIP categorization.
* The upgrade name construction logic has been enhanced: if no paired name exists, both execution and consensus layer upgrade names are combined for more descriptive labeling.
* The grouping logic now uses `dateGroups.push` for all upgrades (including the special Petersburg/Constantinople case), standardizing how upgrade rows are created and improving code clarity.
* Minor cleanups to EIP categorization: removed redundant comments and clarified how removed EIPs are handled within the core category. [[1]](diffhunk://#diff-22493077629b8aa6550146b10f1a3168687583b94df9b1b90de0da375885304eL543) [[2]](diffhunk://#diff-22493077629b8aa6550146b10f1a3168687583b94df9b1b90de0da375885304eL555)

**Navbar Component Update:**

* The months displayed for the year "2025" in the `Navbar` now use the `getMonthsTillYear(2025)` function, ensuring correct month selection logic.