### PR TITLE
Safely read redirects param in getServerSideProps

### DIFF
--- a/src/pages/[redirects]/index.tsx
+++ b/src/pages/[redirects]/index.tsx
@@ -7,8 +7,10 @@ const RedirectsPage = () => {
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const { params } = context;
-  const path = params?.slug?.[0].toLowerCase(); // Get the path and convert it to lowercase
-  console.log(path);
+  const path =
+    typeof params?.redirects === 'string'
+      ? params.redirects.toLowerCase()
+      : undefined; // Get the path and convert it to lowercase
   if (path === 'reviewers') {
     return {
       redirect: {


### PR DESCRIPTION
### Motivation
- Fix a runtime error by ensuring the route parameter is read with the correct name and only lowercased when it is a defined string.
- Prevent calling `.toLowerCase()` on `undefined` or non-string values coming from `context.params`.
- Keep the existing 404 fallback for unknown paths to avoid accidentally returning pages for invalid redirects.
- Clarify behavior for the `[redirects]` dynamic route handler in `getServerSideProps`.

### Description
- Updated `src/pages/[redirects]/index.tsx` to read `params.redirects` safely using `typeof params?.redirects === 'string' ? params.redirects.toLowerCase() : undefined`.
- Removed the previous unsafe access to `params?.slug?.[0].toLowerCase()` and the debug `console.log` call.
- Preserved existing redirect logic for `reviewers` and `analytics` and retained the `notFound: true` fallback.
- The fix confines the `.toLowerCase()` call to a defined string to avoid runtime exceptions in `getServerSideProps`.

### Testing
- No automated tests were run for this change.
- The change was committed and the modified file is `src/pages/[redirects]/index.tsx`.
- Manual validation is recommended for route permutations including missing `params` and multi-segment paths.
- Consider adding unit or integration tests for `getServerSideProps` to cover null and non-string param cases.