### PR TITLE
Refactor view counter to Next.js API handler

### DIFF
--- a/src/pages/api/count/viewCounter.tsx
+++ b/src/pages/api/count/viewCounter.tsx
@@ -1,23 +1,34 @@
-import express from 'express';
+import type { NextApiRequest, NextApiResponse } from 'next';
 import fs from 'fs';
-const path = require('path');
+import path from 'path';
 
-const app = express();
 let viewsCount = 9000;
 
-app.use(express.json());
-app.use(express.urlencoded({ extended: true }));
-
-app.get('/api/count/viewCounter', (req, res) => {
-    res.json({ viewsCount });
-});
-
-app.post('/api/count/viewCounter', (req, res) => {
-    viewsCount++;
-    res.json({ viewsCount });
-});
+const viewsFilePath = path.join(__dirname, 'data', 'views.json');
 
 setInterval(() => {
-    const viewsFilePath = path.join(__dirname, 'data', 'views.json');
+    fs.mkdirSync(path.dirname(viewsFilePath), { recursive: true });
     fs.writeFileSync(viewsFilePath, JSON.stringify({ viewsCount }));
 }, 15000);
+
+export default async function handler(
+    req: NextApiRequest,
+    res: NextApiResponse
+) {
+    switch (req.method) {
+        case 'GET': {
+            res.status(200).json({ viewsCount });
+            return;
+        }
+        case 'POST': {
+            viewsCount++;
+            res.status(200).json({ viewsCount });
+            return;
+        }
+        default: {
+            res
+                .status(405)
+                .json({ error: `Method ${req.method ?? 'UNKNOWN'} Not Allowed` });
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Replace the custom Express server code in the API route with a standard Next.js API handler for compatibility and simplicity.
- Provide explicit handling for `GET` and `POST` methods and a clear 405 response for unsupported methods.
- Ensure persisted view counts are written safely by creating the `data/` directory before writing the file.

### Description
- Removed the Express app and middleware and added `export default async function handler(req: NextApiRequest, res: NextApiResponse)` as the route entry point.
- Implemented a `switch` on `req.method` to handle `GET` (return `viewsCount`) and `POST` (increment and return `viewsCount`) with consistent `JSON` responses.
- Added `viewsFilePath = path.join(__dirname, 'data', 'views.json')` and call `fs.mkdirSync(path.dirname(viewsFilePath), { recursive: true })` before `fs.writeFileSync` in the existing interval-based persistence.
- Updated imports to use `import type { NextApiRequest, NextApiResponse } from 'next'` and `import path from 'path'`.

### Testing
- No automated tests were run for this change.
- Manual inspection and static checks were used to verify the handler compiles as a Next.js API route.