### PR TITLE
Fix dislike count increment

### DIFF
--- a/src/pages/api/count/dislike.tsx
+++ b/src/pages/api/count/dislike.tsx
@@ -40,7 +40,7 @@ export default async (req: Request, res: Response) => {
         }
     
         // Increment the like count
-        likeDoc.likeCount++;
+        likeDoc.dislikeCount++;
         await likeDoc.save();
     
           res.json({ pageName, likeCount: likeDoc.likeCount, dislikeCount: likeDoc.dislikeCount });
@@ -49,5 +49,4 @@ export default async (req: Request, res: Response) => {
         res.status(500).json({ error: 'Internal server error' });
       }
 };
-
 


### PR DESCRIPTION
### Motivation
- Correct the mutation in the dislike API so that the `dislike` endpoint actually increments the dislike counter instead of the like counter.
- Preserve the existing response payload structure while ensuring the returned `dislikeCount` reflects the increment.
- Ensure the document default initialization includes both `likeCount` and `dislikeCount` set to zero.

### Description
- Updated `src/pages/api/count/dislike.tsx` to increment `dislikeCount` instead of `likeCount` by changing `likeDoc.likeCount++` to `likeDoc.dislikeCount++`.
- Kept the response JSON unchanged as `res.json({ pageName, likeCount: likeDoc.likeCount, dislikeCount: likeDoc.dislikeCount })` so callers receive the same payload shape.
- Verified the default document creation uses `new Like({ pageName, likeCount: 0, dislikeCount: 0 })` to initialize both counters to zero.

### Testing
- No automated tests were run for this change.
- The change is limited to a single-line mutation and retains the existing response shape to minimize regression risk.