### PR TITLE
Fix Sepolia Pectra post link and description in PectraPosts 

### DIFF
--- a/src/pages/pectra/index.tsx
+++ b/src/pages/pectra/index.tsx
@@ -193,8 +193,8 @@ const All = () => {
     {
       image: "pectraimg6.jpg",
       title: "Sepolia Pectra Incident Update",
-      content: "A sneak peek at how the Ethereum community came together to fix Holesky after two weeks of chaos.",
-      link: "At 7:29 UTC today, on epoch 222464, the Pectra network upgrade went live on the Sepolia testnet. Unfortunately, an issue with Sepolia's permissioned deposit contract prevented many execution layer clients from including transactions in blocks."
+      content: "At 7:29 UTC today, on epoch 222464, the Pectra network upgrade went live on the Sepolia testnet. Unfortunately, an issue with Sepolia's permissioned deposit contract prevented many execution layer clients from including transactions in blocks.",
+      link: "https://blog.ethereum.org/2025/03/05/sepolia-pectra-incident-update"
     },
   ]
 

--- a/src/pages/pectra/index.tsx
+++ b/src/pages/pectra/index.tsx
@@ -194,7 +194,7 @@ const All = () => {
       image: "pectraimg6.jpg",
       title: "Sepolia Pectra Incident Update",
       content: "At 7:29 UTC today, on epoch 222464, the Pectra network upgrade went live on the Sepolia testnet. Unfortunately, an issue with Sepolia's permissioned deposit contract prevented many execution layer clients from including transactions in blocks.",
-      link: "https://blog.ethereum.org/2025/03/05/sepolia-pectra-incident-update"
+      link: "https://blog.ethereum.org/2025/03/05/sepolia-pectra-incident"
     },
   ]
 


### PR DESCRIPTION
### Motivation
- Fix the malformed entry in `PectraPosts` so the card renders a valid link and description. 
- Ensure long explanatory text is used as the card `content` rather than accidentally placed in the `link` field. 
- Prevent UI/UX issues where a non-URL string would be rendered as a link for the Sepolia post. 

### Description
- Moved the Sepolia incident explanatory text into the `content` field for the last `PectraPosts` item. 
- Replaced the malformed `link` value with the canonical blog URL `https://blog.ethereum.org/2025/03/05/sepolia-pectra-incident`. 
- Updated `src/pages/pectra/index.tsx` to reflect the corrected `PectraPosts` entry. 

### Testing
- No automated tests were run for this content-only change. 
- Change is limited to a data object update in `src/pages/pectra/index.tsx` and does not alter component logic.