### PR TITLE
Remove conflicting /pectra redirect from next.config.mjs

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -55,15 +55,7 @@ const nextConfig = withMDX(
 
     // Add the redirects method here
     async redirects() {
-      return [
-        // Redirect lowercase 'reviewers' to properly cased 'Reviewers', only if the pathname is not already correct
-        {
-          source: '/pectra',
-          destination: '/upgrade',
-          permanent: true,
-          has: [{ type: 'header', key: 'x-original-path', value: '/pectra' }]
-        },
-      ];
+      return [];
     }
   })
 );


### PR DESCRIPTION
### Motivation
- A redirect for `/pectra` in `next.config.mjs` used a `has` header condition (`x-original-path`) that can conflict with the existing `/pectra` page and unintentionally intercept requests.
- The `has` condition should only be used if the header is explicitly set elsewhere or replaced with a condition under project control (e.g., a cookie or query param).
- To avoid unexpected routing behavior, the redirect entry is removed until a controlled gating mechanism is required.

### Description
- Updated `next.config.mjs` and replaced the existing `async redirects()` return value with an empty array (`return [];`).
- Removed the redirect object that matched `source: '/pectra'` and redirected to `/upgrade` with a `has` header condition referencing `x-original-path`.
- No other configuration or behavior was changed beyond clearing the `redirects` list.

### Testing
- No automated tests were executed for this config-only change.
- No build or runtime validation was performed as part of this update.