### PR TITLE
Fix event filtering for subscriptions

### DIFF
--- a/src/utils/sync.ts
+++ b/src/utils/sync.ts
@@ -50,9 +50,11 @@ export async function syncEipChanges() {
 
     // Mark latest SHA AFTER successful notifications
     const statusEvents = changes.events.filter((e) => e.kind === 'status');
+    const contentEvents = changes.events.filter((e) => e.kind === 'content');
+    const allEvents = [...statusEvents, ...contentEvents];
     for (const sub of groupSubs) {
       const relevant =
-        sub.filter === 'status' ? statusEvents : changes.events.filter((e) => sub.filter === 'all' || e.kind === 'status');
+        sub.filter === 'status' ? statusEvents : sub.filter === 'content' ? contentEvents : allEvents;
 
       if (!relevant.length) {
         console.log(`⚠️ No relevant events for ${sub.email} on ${key.type}-${key.id}`);


### PR DESCRIPTION
### Motivation
- Ensure each subscription `filter` receives only the intended event kinds (`status`, `content`, or both).
- Avoid computing the filtered list multiple times and guarantee the same list is passed to the email builder.
- Prevent subscribers from receiving irrelevant events when `filter` is set to `status` or `content`.

### Description
- Precomputed `statusEvents`, `contentEvents`, and combined `allEvents` from `changes.events` in `src/utils/sync.ts`.
- Replaced the previous inline filtering with a single selection that routes `sub.filter === 'status'` to `statusEvents`, `sub.filter === 'content'` to `contentEvents`, and all others to `allEvents`.
- Continued to pass the selected `relevant` events through `dedupeEvents` and then into `buildChangeEmail` to preserve de-duplication behavior.

### Testing
- No automated tests were run.