### PR TITLE
Add aggregated /api/insight-stats endpoint and simplify InsightStats component 

### DIFF
--- a/src/components/InsightStats.tsx
+++ b/src/components/InsightStats.tsx
@@ -14,24 +14,18 @@ import {
 } from "@chakra-ui/react";
 import { usePathname } from "next/navigation";
 
-type PR = {
-  prNumber: number;
-  prTitle: string;
-  created_at: Date;
-  closed_at: Date | null;
-  merged_at: Date | null;
+type InsightStatCounts = {
+  open: number;
+  created: number;
+  closed: number;
+  merged: number;
 };
 
-type Issue = {
-  IssueNumber: number;
-  IssueTitle: string;
-  state: string;
-  created_at: Date;
-  closed_at: Date | null;
+type InsightStatsPayload = {
+  key: string;
+  prs: Record<string, Record<string, InsightStatCounts>>;
+  issues: Record<string, Record<string, InsightStatCounts>>;
 };
-
-const PR_API_ENDPOINTS = ['/api/eipsprdetails', '/api/ercsprdetails', '/api/ripsprdetails'];
-const ISSUE_API_ENDPOINTS = ['/api/eipsissuedetails', '/api/ercsissuedetails', '/api/ripsissuedetails'];
 
 export default function InsightStats() {
   const bg = useColorModeValue("#f6f6f7", "#171923");
@@ -44,9 +38,8 @@ export default function InsightStats() {
     month = pathParts[3];
   }
 
-  const key = `${year}-${month}`; // Combine year and month for the key
-
-  console.log("key:",key);
+  const formattedMonth = month ? month.padStart(2, "0") : "";
+  const key = year && formattedMonth ? `${year}-${formattedMonth}` : "";
 
   const [prData, setPrData] = useState({
     EIPs: { open: 0, created: 0, closed: 0, merged: 0 },
@@ -60,443 +53,69 @@ export default function InsightStats() {
   });
 
   useEffect(() => {
-    fetchPRData();
-    fetchIssueData();
+    if (!key) {
+      return;
+    }
+    fetchInsightStats();
   }, [key]);
 
-  const fetchPRData = async () => {
+  const fetchInsightStats = async () => {
     try {
-        const prResults = await Promise.all(
-            PR_API_ENDPOINTS?.map(endpoint => fetch(endpoint).then(res => res.json()))
-          ) as PR[][]; // Define as PR[][] to allow for any number of returned arrays
-    
-          const [eipsPRs, ercsPRs, ripsPRs] = prResults;
-
-      const transformedEipsData = transformPRData(eipsPRs, key);
-      const transformedErcsData = transformPRData(ercsPRs, key);
-      const transformedRipsData = transformPRData(ripsPRs, key);
+      const response = await fetch(`/api/insight-stats?year=${year}&month=${formattedMonth}`);
+      const payload = (await response.json()) as InsightStatsPayload;
+      const currentKey = payload.key ?? key;
+      const prStats = {
+        EIPs: payload.prs?.EIPs?.[currentKey],
+        ERCs: payload.prs?.ERCs?.[currentKey],
+        RIPs: payload.prs?.RIPs?.[currentKey],
+      };
+      const issueStats = {
+        EIPs: payload.issues?.EIPs?.[currentKey],
+        ERCs: payload.issues?.ERCs?.[currentKey],
+        RIPs: payload.issues?.RIPs?.[currentKey],
+      };
 
       setPrData({
         EIPs: {
-          open: transformedEipsData[key].open?.length,
-          created: transformedEipsData[key].created?.length,
-          closed: transformedEipsData[key].closed?.length,
-          merged: transformedEipsData[key].merged?.length,
+          open: prStats.EIPs?.open ?? 0,
+          created: prStats.EIPs?.created ?? 0,
+          closed: prStats.EIPs?.closed ?? 0,
+          merged: prStats.EIPs?.merged ?? 0,
         },
         ERCs: {
-          open: transformedErcsData[key].open?.length,
-          created: transformedErcsData[key].created?.length,
-          closed: transformedErcsData[key].closed?.length,
-          merged: transformedErcsData[key].merged?.length,
+          open: prStats.ERCs?.open ?? 0,
+          created: prStats.ERCs?.created ?? 0,
+          closed: prStats.ERCs?.closed ?? 0,
+          merged: prStats.ERCs?.merged ?? 0,
         },
         RIPs: {
-          open: transformedRipsData[key].open?.length,
-          created: transformedRipsData[key].created?.length,
-          closed: transformedRipsData[key].closed?.length,
-          merged: transformedRipsData[key].merged?.length,
+          open: prStats.RIPs?.open ?? 0,
+          created: prStats.RIPs?.created ?? 0,
+          closed: prStats.RIPs?.closed ?? 0,
+          merged: prStats.RIPs?.merged ?? 0,
         },
       });
-    } catch (error) {
-      console.error('Error fetching PR data:', error);
-    }
-  };
-
-  const fetchIssueData = async () => {
-    try {
-        const issueResults = await Promise.all(
-            ISSUE_API_ENDPOINTS?.map(endpoint => fetch(endpoint).then(res => res.json()))
-          ) as Issue[][]; // Define as Issue[][] to allow for any number of returned arrays
-    
-      const [eipsIssues, ercsIssues, ripsIssues] = issueResults;
-      const transformedEipsIssue = transformIssueData(eipsIssues, key);
-      const transformedErcsIssue = transformIssueData(ercsIssues, key);
-      const transformedRipsIssue = transformIssueData(ripsIssues, key);
 
       setIssueData({
         EIPs: {
-          open: transformedEipsIssue[key].open?.length,
-          created: transformedEipsIssue[key].created?.length,
-          closed: transformedEipsIssue[key].closed?.length,
+          open: issueStats.EIPs?.open ?? 0,
+          created: issueStats.EIPs?.created ?? 0,
+          closed: issueStats.EIPs?.closed ?? 0,
         },
         ERCs: {
-          open: transformedErcsIssue[key].open?.length,
-          created: transformedErcsIssue[key].created?.length,
-          closed: transformedErcsIssue[key].closed?.length,
+          open: issueStats.ERCs?.open ?? 0,
+          created: issueStats.ERCs?.created ?? 0,
+          closed: issueStats.ERCs?.closed ?? 0,
         },
         RIPs: {
-          open: transformedRipsIssue[key].open?.length,
-          created: transformedRipsIssue[key].created?.length,
-          closed: transformedRipsIssue[key].closed?.length,
+          open: issueStats.RIPs?.open ?? 0,
+          created: issueStats.RIPs?.created ?? 0,
+          closed: issueStats.RIPs?.closed ?? 0,
         },
       });
     } catch (error) {
-      console.error('Error fetching issue data:', error);
+      console.error('Error fetching insight stats:', error);
     }
-  };
-
-  // const transformPRData = (data: PR[], key: string) => {
-  //   const monthYearData = { PRs: { created: [] as PR[], closed: [] as PR[], merged: [] as PR[], open: [] as PR[] } };
-
-  //   data?.forEach(pr => {
-  //     const createdDate = pr.created_at ? new Date(pr.created_at) : null;
-  //     const closedDate = pr.closed_at ? new Date(pr.closed_at) : null;
-  //     const mergedDate = pr.merged_at ? new Date(pr.merged_at) : null;
-  //     const createdKey = createdDate ? `${createdDate.getUTCFullYear()}-${String(createdDate.getUTCMonth() + 1).padStart(2, '0')}` : '';
-  //     const closedKey = closedDate ? `${closedDate.getUTCFullYear()}-${String(closedDate.getUTCMonth() + 1).padStart(2, '0')}` : '';
-  //     const mergedKey = mergedDate ? `${mergedDate.getUTCFullYear()}-${String(mergedDate.getUTCMonth() + 1).padStart(2, '0')}` : '';
-
-  //     if (createdKey === key) monthYearData.PRs.created.push(pr);
-  //     if (closedKey === key) monthYearData.PRs.closed.push(pr);
-  //     if (mergedKey === key) monthYearData.PRs.merged.push(pr);
-  //   });
-
-  //   return monthYearData;
-  // };
-
-  // const transformIssueData = (data: Issue[], key: string) => {
-  //   const monthYearData = { Issues: { created: [] as Issue[], closed: [] as Issue[], open: [] as Issue[] } };
-
-  //   data?.forEach(issue => {
-  //     const createdDate = new Date(issue.created_at);
-  //     const closedDate = issue.closed_at ? new Date(issue.closed_at) : null;
-  //     const createdKey = `${createdDate.getUTCFullYear()}-${String(createdDate.getUTCMonth() + 1).padStart(2, '0')}`;
-  //     const closedKey = closedDate ? `${closedDate.getUTCFullYear()}-${String(closedDate.getUTCMonth() + 1).padStart(2, '0')}` : '';
-
-  //     if (createdKey === key) monthYearData.Issues.created.push(issue);
-  //     if (closedKey === key) monthYearData.Issues.closed.push(issue);
-
-  //     // Add open issues logic as required based on your criteria
-  //   });
-
-  //   return monthYearData;
-  // };
-
-  const transformPRData = (data: PR[], requiredkey: string): { [key: string]: { created: PR[], closed: PR[], merged: PR[], open:PR[] } } => {
-    const monthYearData: { [key: string]: { created: PR[], closed: PR[], merged: PR[] ,open:[]} } = {};
-    const res: { [key: string]: { created: PR[], closed: PR[], merged: PR[] ,open:[]} } = {};
-    const incrementMonth = (date: Date) => {
-      const newDate = new Date(date);
-      newDate.setMonth(newDate.getMonth() + 1);
-      newDate.setDate(1); // Reset to the first day of the next month
-      newDate.setHours(0, 0, 0, 0);
-      return newDate;
-    };
-    const currentDate = new Date();
-
-    const addIfNotExists = (arr: PR[], pr: PR) => {
-   
-      // Check if the PR has a closing date, and if it is in the current month and year
-      const isClosedThisMonth = pr.closed_at &&
-        new Date(pr.closed_at).getFullYear() === currentDate.getFullYear() &&
-        new Date(pr.closed_at).getMonth() === currentDate.getMonth();
-        if (!isClosedThisMonth && !arr.some(existingPr => existingPr.prNumber === pr.prNumber)) {
-          arr.push(pr);
-        }
-    };
-    const addReview= (arr: PR[], pr: PR) => {
-      if (!arr.some(existingPr => existingPr.prNumber === pr.prNumber)) {
-        arr.push(pr);
-      }
-    };
-
-  
-
-    data?.forEach(pr => {
-      const createdDate = pr.created_at ? new Date(pr.created_at) : null;
-      const closedDate = pr.closed_at ? new Date(pr.closed_at) : null;
-      const mergedDate = pr.merged_at ? new Date(pr.merged_at) : null;
-  
-      // Handle created date
-      if (createdDate) {
-          const key = `${createdDate.getUTCFullYear()}-${String(createdDate.getUTCMonth() + 1).padStart(2, '0')}`;
-          if (!monthYearData[key]) monthYearData[key] = { created: [], closed: [], merged: [], open: [] };
-          addReview(monthYearData[key].created, pr);
-      }
-  
-      // Handle closed date (only if not merged)
-      if (closedDate && !mergedDate) {
-          const key = `${closedDate.getUTCFullYear()}-${String(closedDate.getUTCMonth() + 1).padStart(2, '0')}`;
-          if (!monthYearData[key]) monthYearData[key] = { created: [], closed: [], merged: [], open: []};
-          addReview(monthYearData[key].closed, pr);
-      }
-  
-      // Handle merged date
-      if (mergedDate) {
-          const key = `${mergedDate.getUTCFullYear()}-${String(mergedDate.getUTCMonth() + 1).padStart(2, '0')}`;
-          if (!monthYearData[key]) monthYearData[key] = { created: [], closed: [], merged: [], open: []};
-          addReview(monthYearData[key].merged, pr);
-      }
-  
-      // Handle open PRs
-      if (createdDate) {
-        let createdDateObj = new Date(createdDate);
-        let createdYear = createdDateObj.getUTCFullYear();
-        let createdMonth = createdDateObj.getUTCMonth(); // 0-indexed month
-    
-        // Initialize endDate based on closedDate or currentDate
-let endDate;
-if (closedDate) {
-    let closedDateObj = new Date(closedDate);
-    endDate = new Date(closedDateObj.getUTCFullYear(), closedDateObj.getUTCMonth() + 1, 1); // Set to the 1st of the month after closing
-} else {
-    endDate = new Date(currentDate.getUTCFullYear(), currentDate.getUTCMonth() + 1, 1); // Set to the 1st of the next month
-}
-
-// Initialize openDate starting from the created date
-let openDate = new Date(createdYear, createdMonth, 1);
-
-// Debugging: Log the initial values
-// console.log(`Created Date: ${createdDateObj}`);
-// console.log(`End Date: ${endDate}`);
-// console.log(`Starting Open Date: ${openDate}`);
-
-// Loop through each month the PR was open
-while (openDate < endDate) {
-    const openKey = `${openDate.getUTCFullYear()}-${String(openDate.getUTCMonth() + 1).padStart(2, '0')}`;
-
-    // Initialize monthYearData for the current month key if not already present
-    if (!monthYearData[openKey]) {
-        monthYearData[openKey] = { created: [], closed: [], merged: [], open: []};
-    }
-
-    // Debugging: Log the current state
-    // console.log(`Adding PR to month: ${openKey}`);
-
-    // Add the PR to the open array for this month
-    addIfNotExists(monthYearData[openKey].open, pr);
-
-    // Increment to the next month
-    openDate.setUTCMonth(openDate.getUTCMonth() + 1); // Move to the first day of the next month
-
-    // Debugging: Log the updated openDate
-    // console.log(`Updated Open Date: ${openDate}`);
-}
-
-    }
-    
-  });
-  
-  console.log(requiredkey);
-
-  console.log(monthYearData[requiredkey]);
-
-  if (monthYearData[requiredkey]) {
-    res[requiredkey] = monthYearData[requiredkey];
-  }
-  
-  // return monthYearData;
-  console.log(res);
-  return res;
-  
-  };
-
-  // const transformIssueData = (data: Issue[], requiredkey: string): { [key: string]: { created: Issue[], closed: Issue[], open:Issue[] } } => {
-  //   const monthYearData: { [key: string]: { created: Issue[], closed: Issue[], open:Issue[] } } = {};
-  //   const res: { [key: string]: { created: Issue[], closed: Issue[], open:Issue[] } } = {};
-  //   const incrementMonth = (date: Date) => {
-  //     const newDate = new Date(date);
-  //     newDate.setMonth(newDate.getMonth() + 1);
-  //     newDate.setDate(1); // Reset to the first day of the next month
-  //     newDate.setHours(0, 0, 0, 0);
-  //     return newDate;
-  //   };
-  //   const currentDate = new Date();
-
-  //   const addIfNotExists = (arr: Issue[], pr: Issue) => {
-   
-  //     // Check if the PR has a closing date, and if it is in the current month and year
-  //     const isClosedThisMonth = pr.closed_at &&
-  //       new Date(pr.closed_at).getFullYear() === currentDate.getFullYear() &&
-  //       new Date(pr.closed_at).getMonth() === currentDate.getMonth();
-  //       if (!isClosedThisMonth && !arr.some(existingPr => existingPr.IssueNumber === pr.IssueNumber)) {
-  //         arr.push(pr);
-  //       }
-  //   };
-
-  //   data?.forEach(issue => {
-  //     const createdDate = new Date(issue.created_at);
-  //     const createdKey = `${createdDate.getUTCFullYear()}-${String(createdDate.getUTCMonth() + 1).padStart(2, '0')}`;
-      
-  //     if (!monthYearData[createdKey]) {
-  //         monthYearData[createdKey] = { created: [], closed: [], open: [] };
-  //     }
-  //     monthYearData[createdKey].created.push(issue);
-  
-  //     if (issue.closed_at) {
-  //         const closedDate = new Date(issue.closed_at);
-  //         const closedKey = `${closedDate.getUTCFullYear()}-${String(closedDate.getUTCMonth() + 1).padStart(2, '0')}`;
-          
-  //         if (!monthYearData[closedKey]) {
-  //             monthYearData[closedKey] = { created: [], closed: [], open: [] };
-  //         }
-  //         monthYearData[closedKey].closed.push(issue);
-  //     }
-  
-  //     // Set openDate to the creation date and endDate to the 1st of the closed month or current month
-  //     let openDate = new Date(createdDate);
-  //     let createdConstant = new Date(createdDate); // Store the creation date separately
-  //     let endDate = issue.closed_at 
-  //         ? new Date(new Date(issue.closed_at).getUTCFullYear(), new Date(issue.closed_at).getUTCMonth(), 1) 
-  //         : new Date(currentDate.getUTCFullYear(), currentDate.getUTCMonth() + 1, 1); // Include the current month
-      
-  //     // Loop through each month the issue was open
-  //     while (openDate <= endDate) { // Open until the start of the closed month or current month
-  //         const openKey = `${openDate.getUTCFullYear()}-${String(openDate.getUTCMonth() + 1).padStart(2, '0')}`;
-      
-  //         if (!monthYearData[openKey]) {
-  //             monthYearData[openKey] = { created: [], closed: [], open: [] };
-  //         }
-      
-  //         // Check if the issue was still open on the 1st of the month
-  //         const firstOfMonth = new Date(openDate.getUTCFullYear(), openDate.getUTCMonth(), 1);
-          
-  //         // Skip if the openDate corresponds to the created month
-  //         if (!(openDate.getUTCFullYear() === createdConstant.getUTCFullYear() && openDate.getUTCMonth() === createdConstant.getUTCMonth())) {
-  //             if (firstOfMonth <= openDate && (!issue.closed_at || firstOfMonth < new Date(issue.closed_at))) {
-  //                 // Add to open only if it's still open on the first of that month
-  //                 addIfNotExists(monthYearData[openKey].open, issue);
-  //             }
-  //         }
-      
-  //         // Move to the next month
-  //         openDate = incrementMonth(openDate);
-  //     }
-      
-  // });
-  
-  // if (monthYearData[requiredkey]) {
-  //   res[requiredkey] = monthYearData[requiredkey];
-  // }
-  //   // return monthYearData;
-  //   return res;
-  // };
-
-  const transformIssueData = (data: Issue[], requiredkey: string): { [key: string]: { created: Issue[], closed: Issue[], open:Issue[] } } => {
-   
-    const monthYearData: { [key: string]: { created: Issue[], closed: Issue[], open:Issue[] } } = {};
-    const res: { [key: string]: { created: Issue[], closed: Issue[], open:Issue[] } } = {};
-    
-    const incrementMonth = (date: Date) => {
-      const newDate = new Date(date);
-      newDate.setMonth(newDate.getMonth() + 1);
-      newDate.setDate(1); // Reset to the first day of the next month
-      newDate.setHours(0, 0, 0, 0);
-      return newDate;
-    };
-    const currentDate = new Date();
-
-    const addIfNotExists = (arr: Issue[], pr: Issue) => {
-   
-      // Check if the PR has a closing date, and if it is in the current month and year
-      const isClosedThisMonth = pr.closed_at &&
-        new Date(pr.closed_at).getFullYear() === currentDate.getFullYear() &&
-        new Date(pr.closed_at).getMonth() === currentDate.getMonth();
-        if (!isClosedThisMonth && !arr.some(existingPr => existingPr.IssueNumber === pr.IssueNumber)) {
-          arr.push(pr);
-        }
-    };
-    const processedIssues = new Set();
-
-    data?.forEach(issue => {
-      if (!processedIssues.has(issue.IssueNumber)) {
-        
-        processedIssues.add(issue.IssueNumber);
-      const createdDate = new Date(issue.created_at);
-      const closedDate = issue.closed_at ? new Date(issue.closed_at) : null;
-      if(issue.IssueNumber==8978 || issue.IssueNumber===8982){
-        console.log("issue: ",issue.IssueNumber)
-        console.log("created date: ",createdDate);
-        console.log(issue);
-        
-      }
-      const createdKey = `${createdDate.getUTCFullYear()}-${String(createdDate.getUTCMonth() + 1).padStart(2, '0')}`;
-      
-      if (!monthYearData[createdKey]) {
-          monthYearData[createdKey] = { created: [], closed: [], open: [] };
-      }
-      monthYearData[createdKey].created.push(issue);
-  
-      if (issue.closed_at) {
-          const closedDate = new Date(issue.closed_at);
-          const closedKey = `${closedDate.getUTCFullYear()}-${String(closedDate.getUTCMonth() + 1).padStart(2, '0')}`;
-          
-          if (!monthYearData[closedKey]) {
-              monthYearData[closedKey] = { created: [], closed: [], open: [] };
-          }
-          monthYearData[closedKey].closed.push(issue);
-      }
-  
-      // Set openDate to the creation date and endDate to the 1st of the closed month or current month
-      // let openDate = new Date(createdDate);
-      // let createdConstant = new Date(createdDate); // Store the creation date separately
-      // let endDate = issue.closed_at 
-      //     ? new Date(new Date(issue.closed_at).getUTCFullYear(), new Date(issue.closed_at).getUTCMonth(), 1) 
-      //     : new Date(currentDate.getUTCFullYear(), currentDate.getUTCMonth() + 1, 1); // Include the current month
-      
-      // // Loop through each month the issue was open
-      // while (openDate <= endDate) { // Open until the start of the closed month or current month
-      //     const openKey = `${openDate.getUTCFullYear()}-${String(openDate.getUTCMonth() + 1).padStart(2, '0')}`;
-      
-      //     if (!monthYearData[openKey]) {
-      //         monthYearData[openKey] = { created: [], closed: [], open: [] };
-      //     }
-      
-      //     // Check if the issue was still open on the 1st of the month
-      //     const firstOfMonth = new Date(openDate.getUTCFullYear(), openDate.getUTCMonth(), 1);
-          
-      //     // Skip if the openDate corresponds to the created month
-      //     if (!(openDate.getUTCFullYear() === createdConstant.getUTCFullYear() && openDate.getUTCMonth() === createdConstant.getUTCMonth())) {
-      //         if (firstOfMonth <= openDate && (!issue.closed_at || firstOfMonth < new Date(issue.closed_at))) {
-      //             // Add to open only if it's still open on the first of that month
-      //             addIfNotExists(monthYearData[openKey].open, issue);
-      //         }
-      //     }
-      
-      //     // Move to the next month
-      //     openDate = incrementMonth(openDate);
-      // }
-
-      if (createdDate) {
-        let createdDateObj = new Date(createdDate);
-        let createdYear = createdDateObj.getUTCFullYear();
-        let createdMonth = createdDateObj.getUTCMonth(); // 0-indexed month
-    
-              // Initialize endDate based on closedDate or currentDate
-      let endDate;
-      if (closedDate) {
-          let closedDateObj = new Date(closedDate);
-          endDate = new Date(closedDateObj.getUTCFullYear(), closedDateObj.getUTCMonth() + 1, 1); // Set to the 1st of the month after closing
-      } else {
-          endDate = new Date(currentDate.getUTCFullYear(), currentDate.getUTCMonth() + 1, 1); // Set to the 1st of the next month
-      }
-
-      // Initialize openDate starting from the created date
-      let openDate = new Date(createdYear, createdMonth, 1);
-
-      while (openDate < endDate) {
-          const openKey = `${openDate.getUTCFullYear()}-${String(openDate.getUTCMonth() + 1).padStart(2, '0')}`;
-          // Initialize monthYearData for the current month key if not already present
-          if (!monthYearData[openKey]) {
-              monthYearData[openKey] = { created: [], closed: [], open: [] };
-          }
-          // Add the PR to the open array for this month
-          addIfNotExists(monthYearData[openKey].open, issue);
-
-          // Increment to the next month
-          openDate.setUTCMonth(openDate.getUTCMonth() + 1); // Move to the first day of the next month
-
-      }
-
-    }
-    }
-  });
-  
-
-  if (monthYearData[requiredkey]) {
-      res[requiredkey] = monthYearData[requiredkey];
-    }
-      // return monthYearData;
-      return res;
   };
 
   return (

--- a/src/pages/api/insight-stats.ts
+++ b/src/pages/api/insight-stats.ts
@@ -1,0 +1,115 @@
+import { Request, Response } from 'express';
+import mongoose from 'mongoose';
+
+if (mongoose.connection.readyState === 0) {
+  if (typeof process.env.MONGODB_URI === 'string') {
+    mongoose.connect(process.env.MONGODB_URI);
+  } else {
+    console.error('MONGODB_URI environment variable is not defined');
+  }
+}
+
+const prDetailsSchema = new mongoose.Schema({
+  createdAt: { type: Date },
+  closedAt: { type: Date },
+  mergedAt: { type: Date },
+});
+
+const issueDetailsSchema = new mongoose.Schema({
+  createdAt: { type: Date },
+  closedAt: { type: Date },
+});
+
+const PrModels = {
+  EIPs: mongoose.models.AllEipsPrDetails || mongoose.model('AllEipsPrDetails', prDetailsSchema),
+  ERCs: mongoose.models.AllErcsPrDetails || mongoose.model('AllErcsPrDetails', prDetailsSchema),
+  RIPs: mongoose.models.AllRipsPrDetails || mongoose.model('AllRipsPrDetails', prDetailsSchema),
+};
+
+const IssueModels = {
+  EIPs: mongoose.models.AllEipsIssueDetails || mongoose.model('AllEipsIssueDetails', issueDetailsSchema),
+  ERCs: mongoose.models.AllErcsIssueDetails || mongoose.model('AllErcsIssueDetails', issueDetailsSchema),
+  RIPs: mongoose.models.AllRipsIssueDetails || mongoose.model('AllRipsIssueDetails', issueDetailsSchema),
+};
+
+const resolveYearMonth = (req: Request) => {
+  const now = new Date();
+  const yearParam = typeof req.query.year === 'string' ? Number.parseInt(req.query.year, 10) : now.getUTCFullYear();
+  const monthParam = typeof req.query.month === 'string' ? Number.parseInt(req.query.month, 10) : now.getUTCMonth() + 1;
+  const year = Number.isFinite(yearParam) ? yearParam : now.getUTCFullYear();
+  const month = Number.isFinite(monthParam) && monthParam >= 1 && monthParam <= 12 ? monthParam : now.getUTCMonth() + 1;
+  return { year, month };
+};
+
+const buildPrStats = async (model: mongoose.Model<any>, startDate: Date, endDate: Date) => {
+  const [open, created, closed, merged] = await Promise.all([
+    model.countDocuments({
+      createdAt: { $lt: endDate },
+      $or: [
+        { closedAt: null },
+        { closedAt: { $exists: false } },
+        { closedAt: { $gte: startDate } },
+      ],
+    }),
+    model.countDocuments({ createdAt: { $gte: startDate, $lt: endDate } }),
+    model.countDocuments({
+      closedAt: { $gte: startDate, $lt: endDate },
+      $or: [{ mergedAt: null }, { mergedAt: { $exists: false } }],
+    }),
+    model.countDocuments({ mergedAt: { $gte: startDate, $lt: endDate } }),
+  ]);
+
+  return { open, created, closed, merged };
+};
+
+const buildIssueStats = async (model: mongoose.Model<any>, startDate: Date, endDate: Date) => {
+  const [open, created, closed] = await Promise.all([
+    model.countDocuments({
+      createdAt: { $lt: endDate },
+      $or: [
+        { closedAt: null },
+        { closedAt: { $exists: false } },
+        { closedAt: { $gte: startDate } },
+      ],
+    }),
+    model.countDocuments({ createdAt: { $gte: startDate, $lt: endDate } }),
+    model.countDocuments({ closedAt: { $gte: startDate, $lt: endDate } }),
+  ]);
+
+  return { open, created, closed, merged: 0 };
+};
+
+export default async (req: Request, res: Response) => {
+  try {
+    const { year, month } = resolveYearMonth(req);
+    const key = `${year}-${String(month).padStart(2, '0')}`;
+    const startDate = new Date(Date.UTC(year, month - 1, 1));
+    const endDate = new Date(Date.UTC(year, month, 1));
+
+    const [eipsPrs, ercsPrs, ripsPrs, eipsIssues, ercsIssues, ripsIssues] = await Promise.all([
+      buildPrStats(PrModels.EIPs, startDate, endDate),
+      buildPrStats(PrModels.ERCs, startDate, endDate),
+      buildPrStats(PrModels.RIPs, startDate, endDate),
+      buildIssueStats(IssueModels.EIPs, startDate, endDate),
+      buildIssueStats(IssueModels.ERCs, startDate, endDate),
+      buildIssueStats(IssueModels.RIPs, startDate, endDate),
+    ]);
+
+    res.json({
+      key,
+      prs: {
+        EIPs: { [key]: eipsPrs },
+        ERCs: { [key]: ercsPrs },
+        RIPs: { [key]: ripsPrs },
+      },
+      issues: {
+        EIPs: { [key]: eipsIssues },
+        ERCs: { [key]: ercsIssues },
+        RIPs: { [key]: ripsIssues },
+      },
+    });
+  } catch (error) {
+    console.error('Error building insight stats:', error);
+    res.status(500).json({ error: 'Something went wrong' });
+  }
+};


### PR DESCRIPTION
### Motivation
- Provide a server-side aggregated monthly summary to avoid expensive client-side per-item aggregation for PRs and issues. 
- Return pre-aggregated monthly counts keyed by `YYYY-MM` for `{ open, created, closed, merged }` to simplify client logic. 
- Eliminate slow O(n*m) loops and debugging noise in the `InsightStats` component. 
- Make counts available per-repo (EIPs, ERCs, RIPs) so UI components can read final values directly.

### Description
- Added a new API endpoint `src/pages/api/insight-stats.ts` that accepts `year` and `month` query params and returns aggregated counts keyed by `YYYY-MM` for PRs and issues per repository. 
- The endpoint computes `open`, `created`, `closed`, and `merged` counts using `countDocuments` queries and returns payload `{ key, prs, issues }`. 
- Updated `src/components/InsightStats.tsx` to fetch `/api/insight-stats?year=...&month=...`, consume the aggregated payload, and populate the table, removing the previous client-side aggregation logic and debug `console.log` lines. 
- Added lightweight TypeScript types for the aggregated payload (`InsightStatCounts`, `InsightStatsPayload`) and defensive fallbacks for missing data.

### Testing
- No automated tests were executed for these changes.