### PR TITLE
Add shared React Query hook useAllEipsData for /api/new/all

### DIFF
--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,7 +1,9 @@
 'use client';
 
+import React from 'react';
 import { CacheProvider } from '@chakra-ui/next-js';
 import { ChakraProvider, ColorModeScript, extendTheme, StyleFunctionProps } from '@chakra-ui/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AuthLocalStorageInitializer } from '@/components/AuthLocalStorageInitializer';
 
 const theme = extendTheme({
@@ -21,12 +23,23 @@ const theme = extendTheme({
 });
 
 export function Providers({ children }: { children: React.ReactNode }) {
+  const [queryClient] = React.useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            refetchOnWindowFocus: false,
+          },
+        },
+      })
+  );
+
   return (
     <CacheProvider>
       <ChakraProvider theme={theme}>
         <ColorModeScript initialColorMode={theme.config.initialColorMode} />
         <AuthLocalStorageInitializer />
-        {children}
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
       </ChakraProvider>
     </CacheProvider>
   );

--- a/src/components/EIPChart.tsx
+++ b/src/components/EIPChart.tsx
@@ -1,8 +1,7 @@
 'use client';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import ReactECharts from 'echarts-for-react';
-import Link from 'next/link';
-import { Spinner } from '@chakra-ui/react';
+import { useAllEipsData } from '@/hooks/useAllEipsData';
 
 const getCat = (cat: string): string => {
   switch (cat) {
@@ -57,20 +56,6 @@ const getStatus = (status: string): string => {
   }
 };
 
-const fetchEIPData = async () => {
-  try {
-    const response = await fetch('/api/new/all');
-    if (!response.ok) {
-      throw new Error('Failed to fetch data');
-    }
-    const data = await response.json();
-    return data;
-  } catch (error) {
-    console.error('Error fetching EIP data:', error);
-    return { eip: [], erc: [], rip: [] }; // Return empty data in case of an error
-  }
-};
-
 const EIPChartWrapper: React.FC<{ type: string }> = ({ type }) => {
   interface EIPData {
     created: string;
@@ -79,19 +64,18 @@ const EIPChartWrapper: React.FC<{ type: string }> = ({ type }) => {
     status: string;
   }
 
-  const [data, setData] = useState<EIPData[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
   const [chartType, setChartType] = useState('category');
-
-  useEffect(() => {
-    fetchEIPData().then((dataset) => {
-      if (type === 'EIP') setData(dataset.eip);
-      else if (type === 'ERC') setData(dataset.erc);
-      else if (type === 'RIP') setData(dataset.rip);
-      else setData([...dataset.eip, ...dataset.erc, ...dataset.rip]);
-      setIsLoading(false);
-    });
-  }, [type]);
+  const { data: allEipsData } = useAllEipsData();
+  const data: EIPData[] =
+    type === 'EIP'
+      ? allEipsData?.eip ?? []
+      : type === 'ERC'
+        ? allEipsData?.erc ?? []
+        : type === 'RIP'
+          ? allEipsData?.rip ?? []
+          : allEipsData
+            ? [...allEipsData.eip, ...allEipsData.erc, ...allEipsData.rip]
+            : [];
 
   const transformedData = data?.reduce(
     (acc, item) => {

--- a/src/components/StatusBox.tsx
+++ b/src/components/StatusBox.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import {
   Box,
   Table,
@@ -12,6 +12,7 @@ import {
 } from "@chakra-ui/react";
 // import { getStatusColorScheme } from "@chakra-ui/alert/dist/alert-context";
 import NextLink from "next/link";
+import { useAllEipsData } from "@/hooks/useAllEipsData";
 
 const getStatus = (status: string) => {
   switch (status) {
@@ -39,31 +40,6 @@ const getStatus = (status: string) => {
   }
 };
 
-interface EIP {
-  _id: string;
-  eip: string;
-  title: string;
-  author: string;
-  status: string;
-  type: string;
-  category: string;
-  created: string;
-  discussion: string;
-  deadline: string;
-  requires: string;
-  unique_ID: number;
-  repo:string;
-  __v: number;
-}
-
-interface APIResponse {
-    eip: EIP[];
-    erc: EIP[];
-    rip: EIP[];
-}
-
-
-
 interface TableItems {
   status: string;
   count: number;
@@ -71,28 +47,8 @@ interface TableItems {
 }
 
 const StatusBox = () => {
-  const [data, setData] = useState<EIP[]>([]);
-
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const response = await fetch(`/api/new/all`);
-        const jsonData: APIResponse = await response.json();
-        console.log("status box data:", jsonData);
-
-        // Safely set data if `eips` is defined
-        if (jsonData.eip) {
-          setData(jsonData.eip);
-        } else {
-          console.error("Error: `eip` data is missing from the response.");
-        }
-      } catch (error) {
-        console.error("Error fetching data:", error);
-      }
-    };
-
-    fetchData();
-  }, []);
+  const { data: allEipsData } = useAllEipsData();
+  const data = allEipsData?.eip ?? [];
 
   // Add a fallback for empty data to avoid runtime errors
   const safeData = data || [];

--- a/src/components/TypeGraphs2.tsx
+++ b/src/components/TypeGraphs2.tsx
@@ -14,7 +14,7 @@ import { useAllEipsData } from "@/hooks/useAllEipsData";
   const { data: allEipsData } = useAllEipsData();
   const data = allEipsData?.eip ?? [];
   const allData =
-    allEipsData?.eip?.concat(allEipsData?.erc?.concat(allEipsData?.rip)) || [];
+    allEipsData?.eip?.concat(allEipsData?.erc?.concat(allEipsData?.rip)) ?? [];
 
   return (
     <>

--- a/src/components/TypeGraphs2.tsx
+++ b/src/components/TypeGraphs2.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { Box, Grid, Text, useColorModeValue } from "@chakra-ui/react";
 import { motion } from "framer-motion";
 import StackedColumnChart from "@/components/StackedColumnChart";
@@ -7,60 +7,14 @@ import AreaC from "@/components/AreaStatus";
 import NextLink from "next/link";
 import StatusChart from "@/components/StatusColumnChart";
 import DateTime from "./DateTime";
+import { useAllEipsData } from "@/hooks/useAllEipsData";
 
-interface EIP {
-  _id: string;
-  eip: string;
-  title: string;
-  author: string;
-  status: string;
-  type: string;
-  category: string;
-  created: string;
-  discussion: string;
-  deadline: string;
-  requires: string;
-  unique_ID: number;
-  repo: string;
-  __v: number;
-}
-
-interface APIResponse {
-  eip: EIP[];
-  erc: EIP[];
-  rip: EIP[];
-}
-
-const TypeGraphs = () => {
+  const TypeGraphs = () => {
   const bg = useColorModeValue("#f6f6f7", "#171923");
-
-  const [data, setData] = useState<EIP[]>([]); // Set initial state as an empty array
-  const [data2, setData2] = useState<APIResponse>({
-    eip: [],
-    erc: [],
-    rip: [],
-  });
-  const [isLoading, setIsLoading] = useState(true); // Loader state
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const response = await fetch(`/api/new/all`);
-        console.log(response);
-        const jsonData = await response.json();
-        setData(jsonData.eip);
-        setData2(jsonData);
-        setIsLoading(false); // Set loader state to false after data is fetched
-      } catch (error) {
-        console.error("Error fetching data:", error);
-        setIsLoading(false); // Set loader state to false even if an error occurs
-      }
-    };
-
-    fetchData();
-  }, []);
-
-  const allData: EIP[] =
-    data2?.eip?.concat(data2?.erc?.concat(data2?.rip)) || [];
+  const { data: allEipsData } = useAllEipsData();
+  const data = allEipsData?.eip ?? [];
+  const allData =
+    allEipsData?.eip?.concat(allEipsData?.erc?.concat(allEipsData?.rip)) || [];
 
   return (
     <>

--- a/src/components/TypeGraphs4.tsx
+++ b/src/components/TypeGraphs4.tsx
@@ -14,7 +14,7 @@ const TypeGraphs = () => {
   const bg = useColorModeValue("#f6f6f7", "#171923");
   const { data: allEipsData } = useAllEipsData();
   const data = allEipsData?.erc ?? [];
-  const allData = allEipsData?.erc || [];
+  const allData = data;
 
   return (
     <>

--- a/src/components/TypeGraphs4.tsx
+++ b/src/components/TypeGraphs4.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { Box, Grid, Text, useColorModeValue } from "@chakra-ui/react";
 import { motion } from "framer-motion";
 import StackedColumnChart from "@/components/StackedColumnChart";
@@ -7,60 +7,14 @@ import AreaC from "@/components/AreaStatus";
 import NextLink from "next/link";
 import StatusChart from "@/components/StatusColumnChart";
 import DateTime from "./DateTime";
+import { useAllEipsData } from "@/hooks/useAllEipsData";
 
-
-interface EIP {
-  _id: string;
-  eip: string;
-  title: string;
-  author: string;
-  status: string;
-  type: string;
-  category: string;
-  created: string;
-  discussion: string;
-  deadline: string;
-  requires: string;
-  unique_ID: number;
-  repo:string;
-  __v: number;
-}
-
-interface APIResponse {
-    eip: EIP[];
-    erc: EIP[];
-    rip: EIP[];
-  }
 
 const TypeGraphs = () => {
   const bg = useColorModeValue("#f6f6f7", "#171923");
-
-  const [data, setData] = useState<EIP[]>([]); // Set initial state as an empty array
-  const [data2, setData2] = useState<APIResponse>({
-    eip: [],
-    erc: [],
-    rip: [],
-  });
-  const [isLoading, setIsLoading] = useState(true); // Loader state
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const response = await fetch(`/api/new/all`);
-        console.log(response);
-        const jsonData = await response.json();
-        setData(jsonData.erc);
-        setData2(jsonData);
-        setIsLoading(false); // Set loader state to false after data is fetched
-      } catch (error) {
-        console.error("Error fetching data:", error);
-        setIsLoading(false); // Set loader state to false even if an error occurs
-      }
-    };
-
-    fetchData();
-  }, []);
-  
-  const allData: EIP[] = data2?.erc|| [];
+  const { data: allEipsData } = useAllEipsData();
+  const data = allEipsData?.erc ?? [];
+  const allData = allEipsData?.erc || [];
 
   return (
     <>

--- a/src/hooks/useAllEipsData.ts
+++ b/src/hooks/useAllEipsData.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+export interface EIP {
+  _id: string;
+  eip: string;
+  title: string;
+  author: string;
+  status: string;
+  type: string;
+  category: string;
+  created: string;
+  discussion: string;
+  deadline: string;
+  requires: string;
+  unique_ID: number;
+  repo: string;
+  __v: number;
+}
+
+export interface AllEipsResponse {
+  eip: EIP[];
+  erc: EIP[];
+  rip: EIP[];
+}
+
+const fetchAllEipsData = async (): Promise<AllEipsResponse> => {
+  const response = await fetch('/api/new/all');
+  if (!response.ok) {
+    throw new Error('Failed to fetch EIPs data');
+  }
+
+  return response.json();
+};
+
+export const useAllEipsData = () =>
+  useQuery<AllEipsResponse>({
+    queryKey: ['all-eips-data'],
+    queryFn: fetchAllEipsData,
+    staleTime: 5 * 60 * 1000,
+  });

--- a/src/hooks/useAllEipsData.ts
+++ b/src/hooks/useAllEipsData.ts
@@ -34,9 +34,12 @@ const fetchAllEipsData = async (): Promise<AllEipsResponse> => {
   return response.json();
 };
 
-export const useAllEipsData = () =>
-  useQuery<AllEipsResponse>({
+export const useAllEipsData = () => {
+  const { data, isLoading, error } = useQuery<AllEipsResponse>({
     queryKey: ['all-eips-data'],
     queryFn: fetchAllEipsData,
     staleTime: 5 * 60 * 1000,
   });
+
+  return { data, isLoading, error };
+};


### PR DESCRIPTION
### Motivation

- Centralize fetching of the `/api/new/all` dataset so multiple components share a single cached request and reduce duplicate network calls.
- Use React Query to provide caching, stale-time control and a single source of truth for EIPs/Ercs/RIPs data.

### Description

- Added a new hook `src/hooks/useAllEipsData.ts` that queries `/api/new/all` using `@tanstack/react-query` and exposes the combined response shape (`eip`, `erc`, `rip`).
- Wired up a `QueryClient` in `src/app/providers.tsx` by wrapping children with `QueryClientProvider` and default query options.
- Updated components to consume the hook instead of performing local `fetch` calls: `src/components/TypeGraphs2.tsx`, `src/components/TypeGraphs4.tsx`, `src/components/EIPChart.tsx`, and `src/components/StatusBox.tsx`, removing redundant fetch/state logic.

### Testing

- No automated tests were executed as part of this change.
- Manual verification steps were not recorded in automated form for this rollout.
- The changes compile-time updated imports and providers for React Query integration but no CI/test run output is available.