### PR TITLE
Support 'content' subscription filter (API, feed, and UI)

### DIFF
--- a/src/components/SubscriptionForm.tsx
+++ b/src/components/SubscriptionForm.tsx
@@ -95,7 +95,7 @@ import { useState, useEffect } from "react";
 interface SubscribeFormProps {
   type?: "eips" | "ercs" | "rips";
   id?: string | number;
-  filter?: "all" | "status";
+  filter?: "all" | "status" | "content";
 }
 
 export function SubscribeForm({ type = "eips", id = "", filter = "all" }: SubscribeFormProps) {
@@ -179,11 +179,12 @@ export function SubscribeForm({ type = "eips", id = "", filter = "all" }: Subscr
 
       <select
         value={selectedFilter}
-        onChange={(e) => setSelectedFilter(e.target.value as "all" | "status")}
+        onChange={(e) => setSelectedFilter(e.target.value as "all" | "status" | "content")}
         className="w-full p-2 border rounded"
       >
         <option value="all">All Changes</option>
         <option value="status">Status Only</option>
+        <option value="content">Content Only</option>
       </select>
 
       <button type="submit" className="w-full bg-blue-600 text-white p-2 rounded">

--- a/src/pages/api/feeds/[type]/[id]/[filter]/route.ts
+++ b/src/pages/api/feeds/[type]/[id]/[filter]/route.ts
@@ -6,7 +6,7 @@ interface Params {
   params: {
     type: 'eips' | 'ercs' | 'rips';
     id: string;
-    filter: 'all' | 'status';
+    filter: 'all' | 'status' | 'content';
   };
 }
 

--- a/src/pages/api/subscribe.ts
+++ b/src/pages/api/subscribe.ts
@@ -12,12 +12,16 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   const session = await getServerSession(req, res, authOptions);
   let { email, type, id, filter } = req.body;
+  const allowedFilters = ['all', 'status', 'content'];
 
   // Use session email if available
   const userEmail = session?.user?.email || email;
 
   if (!userEmail || !type || !id || !filter) {
     return res.status(400).json({ error: 'Missing required fields' });
+  }
+  if (!allowedFilters.includes(filter)) {
+    return res.status(400).json({ error: 'Invalid filter value' });
   }
 
   try {

--- a/src/pages/api/unsubscribe.ts
+++ b/src/pages/api/unsubscribe.ts
@@ -6,9 +6,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
 
   const { email, type, id, filter } = req.body;
+  const allowedFilters = ['all', 'status', 'content'];
 
   if (!email || !type || !id || !filter) {
     return res.status(400).json({ error: 'Missing fields' });
+  }
+  if (!allowedFilters.includes(filter)) {
+    return res.status(400).json({ error: 'Invalid filter value' });
   }
 
   try {

--- a/src/utils/feedData.ts
+++ b/src/utils/feedData.ts
@@ -15,18 +15,20 @@ export interface FeedData {
 
 /**
  * Build feed data for a given proposal.
- * filter: 'all' | 'status'
+ * filter: 'all' | 'status' | 'content'
  */
 export async function getFeedDataFor(
   type: 'eips' | 'ercs' | 'rips',
   id: string | number,
-  filter: 'all' | 'status' = 'all'
+  filter: 'all' | 'status' | 'content' = 'all'
 ): Promise<FeedData> {
   const { events } = await getChangeLog(type, id);
 
   const filteredEvents: ChangeEvent[] =
     filter === 'status'
       ? events.filter(e => e.kind === 'status')
+      : filter === 'content'
+      ? events.filter(e => e.kind === 'content')
       : events;
 
   const baseLink =

--- a/src/utils/subscriptions.ts
+++ b/src/utils/subscriptions.ts
@@ -4,7 +4,7 @@ export interface SubscriptionInput {
   email: string;
   type: 'eips' | 'ercs' | 'rips';
   id: string | number;
-  filter: 'all' | 'status';
+  filter: 'all' | 'status' | 'content';
 }
 
 export async function addSubscription({ email, type, id, filter }: SubscriptionInput) {


### PR DESCRIPTION
### Motivation
- Enable subscribing to content-only changes in addition to existing `all` and `status` filters so users can receive notifications for content edits.
- Ensure feed generation and feed route params can request `content`-only items.
- Validate API inputs so `subscribe`/`unsubscribe` calls accept the new filter and reject invalid values.

### Description
- Added `content` to the `SubscriptionInput` type in `src/utils/subscriptions.ts` so subscriptions can store `filter: 'content'`.
- Extended `getFeedDataFor` in `src/utils/feedData.ts` to accept `filter: 'content'` and return events where `e.kind === 'content'`.
- Updated the feed route param typing in `src/pages/api/feeds/[type]/[id]/[filter]/route.ts` to include `'content'` and pass it to `getFeedDataFor`.
- Added runtime validation in `src/pages/api/subscribe.ts` and `src/pages/api/unsubscribe.ts` to accept only `['all','status','content']`, and exposed the `content` option in the subscription form `src/components/SubscriptionForm.tsx` UI.

### Testing
- Attempted to start the dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000`, which failed because `next` was not found (no running dev verification).
- No other automated tests were executed as part of this change.