### PR TITLE
Include filter in subscription uniqueness checks

### DIFF
--- a/src/pages/api/subscribe.ts
+++ b/src/pages/api/subscribe.ts
@@ -26,7 +26,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   try {
     // Check if subscription already exists
-    const existingSub = await checkExistingSubscription(userEmail, type, id);
+    const existingSub = await checkExistingSubscription(userEmail, type, id, filter);
     
     if (existingSub) {
       return res.status(409).json({ 
@@ -55,7 +55,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 async function checkExistingSubscription(
   email: string, 
   type: string, 
-  id: string
+  id: string,
+  filter: string
 ) {
   const client = await connectToDatabase();
   const db = client.db('eipsinsight');
@@ -63,6 +64,7 @@ async function checkExistingSubscription(
   return await db.collection('subscriptions').findOne({ 
     email, 
     type, 
-    id 
+    id,
+    filter
   });
 }

--- a/src/utils/subscriptions.ts
+++ b/src/utils/subscriptions.ts
@@ -23,10 +23,15 @@ export async function getAllSubscriptions() {
   return db.collection('subscriptions').find({}).toArray();
 }
 
-export async function checkSubscriptionExists(email: string, type: string, id: string) {
+export async function checkSubscriptionExists(
+  email: string,
+  type: string,
+  id: string,
+  filter: string
+) {
   const client = await connectToDatabase();
   const db = client.db('eipsinsight');
-  return await db.collection('subscriptions').findOne({ email, type, id });
+  return await db.collection('subscriptions').findOne({ email, type, id, filter });
 }
 
 // State tracking (last processed commit per (type,id))


### PR DESCRIPTION
### Motivation
- Ensure subscription uniqueness includes `filter` so users can subscribe separately to `status`, `content`, or `all` for the same `(email,type,id)` tuple.
- Align the existence check with the behavior of `addSubscription` which upserts on `{ email, type, id, filter }`.

### Description
- Update `src/pages/api/subscribe.ts` to pass `filter` into `checkExistingSubscription` and keep `filter` validation before the lookup.
- Modify the internal `checkExistingSubscription` function to include `filter` in the Mongo query.
- Update `src/utils/subscriptions.ts` `checkSubscriptionExists` signature and query to use `{ email, type, id, filter }` for consistent uniqueness handling.
- No change to `addSubscription` was required because it already upserts on `{ email, type, id, filter }`.

### Testing
- No automated tests were run.