### PR TITLE
Send subscription confirmation emails with dynamic type/id labels

### DIFF
--- a/src/pages/api/subscribe.ts
+++ b/src/pages/api/subscribe.ts
@@ -43,7 +43,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     });
 
     // Send confirmation email
-    await sendSubscriptionEmail(userEmail, id);
+    await sendSubscriptionEmail(userEmail, { type, id });
 
     return res.status(200).json({ success: true });
   } catch (err) {

--- a/src/utils/mailer.ts
+++ b/src/utils/mailer.ts
@@ -10,17 +10,21 @@ export const transporter = nodemailer.createTransport({
   },
 });
 
-export async function sendSubscriptionEmail(email: string, eipId: string) {
+export async function sendSubscriptionEmail(
+  email: string,
+  subscription: { type: string; id: string }
+) {
+  const subscriptionLabel = `${subscription.type.toUpperCase()}-${subscription.id}`;
   const mailOptions = {
     from: `"EIPs Insight" <${process.env.EMAIL_FROM}>`,
     to: email,
-    subject: `You're now subscribed to EIP-${eipId}`,
+    subject: `You're now subscribed to ${subscriptionLabel}`,
     html: `
       <div style="font-family: sans-serif; max-width: 600px; margin: auto; border: 1px solid #eee; padding: 20px;">
         <h2 style="color: #4a90e2;">✅ Subscription Confirmed</h2>
         <p>Hey there 👋,</p>
-        <p>You’ve successfully subscribed to updates on <strong>EIP-${eipId}</strong>.</p>
-        <p>We’ll notify you when there are changes or new discussions related to this EIP.</p>
+        <p>You’ve successfully subscribed to updates on <strong>${subscriptionLabel}</strong>.</p>
+        <p>We’ll notify you when there are changes or new discussions related to this ${subscription.type.toUpperCase()}.</p>
         <p style="margin-top: 20px;">Stay curious,<br/>The EIPs Insight Team</p>
       </div>
     `,


### PR DESCRIPTION
### Motivation
- Support subscriptions for multiple resource types by including the subscription `type` alongside the `id` in confirmation emails.
- Make email subject and body reflect the actual resource label (e.g., EIP/ERC/RIP) instead of hardcoding `EIP`.

### Description
- Updated `sendSubscriptionEmail` in `src/utils/mailer.ts` to accept a `subscription` object `{ type, id }` and build a `subscriptionLabel` (`TYPE-ID`) for use in the message.
- Rendered the dynamic label in the email `subject` and `html` body and reference the uppercased `type` in the message copy.
- Updated the API handler in `src/pages/api/subscribe.ts` to call `sendSubscriptionEmail(userEmail, { type, id })` when a subscription is created.

### Testing
- No automated tests were run for this change.
- TypeScript and runtime behavior should remain unchanged for callers that now pass the `{ type, id }` object to `sendSubscriptionEmail`.