### PR TITLE
Fix earliest entry selection in EIP table data

### DIFF
--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -177,7 +177,7 @@ const Table: React.FC<TableProps> = ({ type }) => {
         const response2 = await fetch(`/api/new/graphsv4`);
         const jsonData5 = await response2.json();
 
-        // Function to filter only the first occurrence of each unique entry based on eip ID and changeDate
+        // Function to filter only the first (earliest) occurrence of each unique entry based on eip ID and changeDate
         function getEarliestEntries(data:any, key:any) {
           const uniqueEntries:any = {};
 
@@ -185,7 +185,7 @@ const Table: React.FC<TableProps> = ({ type }) => {
             const entryKey = entry[key];
             
             // If this is the first time we see this `key` or if the current entry's date is earlier, store it
-            if (!uniqueEntries[entryKey] || new Date(entry.changeDate) > new Date(uniqueEntries[entryKey].changeDate)) {
+            if (!uniqueEntries[entryKey] || new Date(entry.changeDate) < new Date(uniqueEntries[entryKey].changeDate)) {
               uniqueEntries[entryKey] = entry;
             }
           });


### PR DESCRIPTION
### Motivation
- The deduplication used when building the EIP table kept the latest `changeDate` per EIP instead of the earliest, causing the table to show newer change records rather than the initial entries.

### Description
- In `src/components/Table.tsx` the `getEarliestEntries` function now compares dates with `<` (earlier) instead of `>` so the earliest `changeDate` per `eip` is retained, and the comment was clarified.

### Testing
- No automated tests were run for this change.