### PR TITLE
Require strong ADMIN_JWT_SECRET at startup 

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -4,9 +4,15 @@ import bcrypt from 'bcryptjs';
 import { SignJWT, jwtVerify } from 'jose';
 import { cookies } from 'next/headers';
 
-const JWT_SECRET = new TextEncoder().encode(
-  process.env.ADMIN_JWT_SECRET || 'fallback-secret-change-in-production'
-);
+const adminJwtSecret = process.env.ADMIN_JWT_SECRET;
+
+if (!adminJwtSecret || adminJwtSecret.trim().length < 32) {
+  throw new Error(
+    'ADMIN_JWT_SECRET must be set to a strong secret (at least 32 characters).'
+  );
+}
+
+const JWT_SECRET = new TextEncoder().encode(adminJwtSecret);
 
 export interface AdminSession {
   userId: string;


### PR DESCRIPTION
### Motivation
- The code used a weak fallback JWT secret which could allow admin token forgery when `ADMIN_JWT_SECRET` is not set, so the application must enforce a strong secret at startup.

### Description
- Remove the insecure fallback and add a startup check that throws unless `ADMIN_JWT_SECRET` is present and at least 32 characters, then use it to derive `JWT_SECRET` via `TextEncoder().encode(...)`.

### Testing
- No automated tests were run for this change.