### PR TITLE
Fix Stripe cancel subscription logging

### DIFF
--- a/src/pages/api/stripe/cancel-subscription.ts
+++ b/src/pages/api/stripe/cancel-subscription.ts
@@ -29,7 +29,7 @@ export default async function handler(
       email: session.user.email
     });
 
-    console.log("user data:",)
+    console.log("user data:", user);
 
     if (!user?.stripeCustomerId) {
       return res.status(400).json({ error: 'No subscription found' });


### PR DESCRIPTION
### Motivation
- Correct an incorrect logging call in the Stripe cancel-subscription API handler so the fetched user record is actually logged for debugging and to avoid the invalid/empty log argument.

### Description
- Replaced the stray/empty `console.log("user data:",)` with `console.log("user data:", user)` in `src/pages/api/stripe/cancel-subscription.ts` to log the retrieved user document.

### Testing
- No automated tests were run for this change.