### PR TITLE
Update reviewers list to include 'jochem-brouwer' in both the ReviewT…

### DIFF
--- a/src/pages/Reviewers/index.tsx
+++ b/src/pages/Reviewers/index.tsx
@@ -164,7 +164,7 @@ const ReviewTracker = () => {
       // Match unique reviewers using a regex to handle YAML structure
       const matches = text.match(/-\s(\w+)/g);
       const reviewers = matches ? Array.from(new Set(matches?.map((m) => m.slice(2)))) : [];
-      const additionalReviewers = ["nalepae","SkandaBhat","advaita-saha","Marchhill","bomanaps","daniellehrner","CarlBeek","nconsigny","yoavw", "adietrichs"];
+      const additionalReviewers = ["nalepae","SkandaBhat","advaita-saha","jochem-brouwer","Marchhill","bomanaps","daniellehrner","CarlBeek","nconsigny","yoavw", "adietrichs"];
 
       // Merge the two arrays and ensure uniqueness
       const updatedReviewers = Array.from(new Set([...reviewers, ...additionalReviewers]));
@@ -578,7 +578,7 @@ const generateCSVData3 = (reviewer: string) => {
 
       // console.log("reviewers:",reviewers);
       // const githubHandles = await fetchReviewers();
-      const githubHandles = ["axic", "gcolvin", "lightclient", "SamWilsn", "xinbenlv", "g11tech", "cdetrio", "Pandapip1", "Souptacular", "wanderer", "MicahZoltu","nalepae","SkandaBhat","advaita-saha","Marchhill","bomanaps","daniellehrner","CarlBeek","nconsigny","yoavw", "adietrichs"];
+      const githubHandles = ["axic", "gcolvin", "lightclient", "SamWilsn", "xinbenlv", "g11tech", "cdetrio", "Pandapip1", "Souptacular", "wanderer", "MicahZoltu","nalepae","SkandaBhat","advaita-saha","jochem-brouwer","Marchhill","bomanaps","daniellehrner","CarlBeek","nconsigny","yoavw", "adietrichs"];
       const githubHandles2 = await fetchReviewers();
       // console.log("active:",activereviewers);
       

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -144,6 +144,7 @@ export const fetchReviewers = async (): Promise<string[]> => {
       'nalepae',
       'SkandaBhat',
       'advaita-saha',
+      'jochem-brouwer',
       'Marchhill',
       'bomanaps',
       'daniellehrner',


### PR DESCRIPTION
This pull request updates the list of reviewers throughout the codebase by adding a new reviewer, `jochem-brouwer`, to all relevant arrays and functions. This ensures that `jochem-brouwer` is now consistently included wherever reviewer lists are used or generated.

Reviewer list updates:

* Added `jochem-brouwer` to the `additionalReviewers` array in the `ReviewTracker` component (`src/pages/Reviewers/index.tsx`).
* Added `jochem-brouwer` to the `githubHandles` array used for generating CSV data in the `generateCSVData3` function (`src/pages/Reviewers/index.tsx`).
* Included `jochem-brouwer` in the hardcoded reviewer list returned by the `fetchReviewers` helper function (`src/utils/helpers.ts`).