### PR TITLE
Enhance NetworkUpgradesChart with new EIPs and categories

### DIFF
--- a/src/components/ZoomableTimeline.tsx
+++ b/src/components/ZoomableTimeline.tsx
@@ -12,9 +12,10 @@ import { AddIcon, MinusIcon, RepeatIcon } from '@chakra-ui/icons';
 interface ZoomableTimelineProps {
   svgPath: string;
   alt?: string;
+  height?: string | number;
 }
 
-const ZoomableTimeline: React.FC<ZoomableTimelineProps> = ({ svgPath, alt = 'Timeline' }) => {
+const ZoomableTimeline: React.FC<ZoomableTimelineProps> = ({ svgPath, alt = 'Timeline', height }) => {
   const [scale, setScale] = useState(1);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -35,7 +36,7 @@ const ZoomableTimeline: React.FC<ZoomableTimelineProps> = ({ svgPath, alt = 'Tim
 
 
   return (
-    <Box position="relative">
+    <Box position="relative" h={height === '100%' ? '100%' : undefined}>
       {/* Timeline Container */}
       <Box
         ref={containerRef}
@@ -46,7 +47,7 @@ const ZoomableTimeline: React.FC<ZoomableTimelineProps> = ({ svgPath, alt = 'Tim
         overflow="hidden"
         position="relative"
         width="100%"
-        height={{ base: '400px', md: '500px', lg: '600px' }}
+        height={height === '100%' ? '100%' : (height || { base: '400px', md: '500px', lg: '600px' })}
         transition="all 0.2s ease"
         boxShadow="sm"
         _hover={{

--- a/src/pages/upgrade/index.tsx
+++ b/src/pages/upgrade/index.tsx
@@ -2221,12 +2221,12 @@ return (
   templateColumns={{ base: '1fr', lg: '1fr 1fr' }}
   gap={5}
   mb={5}
-  alignItems="stretch"   // ⭐ KEY LINE
+  alignItems="stretch"
 >
 
             {/* Left: Stats Cards */}
-            <GridItem display="flex">
-              <VStack spacing={4} w="100%">
+            <GridItem display="flex" h="100%">
+              <VStack spacing={4} w="100%" h="100%" justify="flex-start">
                 <Box
                   as={motion.div}
                   whileHover={{ y: -4, scale: 1.02 }}
@@ -2358,10 +2358,11 @@ return (
             </GridItem>
 
             {/* Right: EIP Inclusion Flowchart (Zoomable controls like ZoomableTimeline) */}
-            <GridItem display={{ base: 'none', lg: 'block' }}>
+            <GridItem display={{ base: 'none', lg: 'block' }} h="100%">
               <ZoomableTimeline
                 svgPath="/stages/eip-incl.png"
                 alt="EIP Inclusion Process Flowchart"
+                height="100%"
               />
             </GridItem>
 


### PR DESCRIPTION
This pull request enhances the `NetworkUpgradesChart` and related components to improve the display and handling of Ethereum network upgrade data, especially for upgrades with paired names and multiple EIPs. The changes focus on better categorization, more accurate meta EIP handling, improved tooltip information, and layout flexibility for visual components.

**Network upgrades and EIP data improvements:**

- Added support for new EIP categories (including 'Interface'), and included additional EIPs (`EIP-7892`, `EIP-7642`, `EIP-7910`, `EIP-7935`) in the `eipTitles` mapping. [[1]](diffhunk://#diff-22493077629b8aa6550146b10f1a3168687583b94df9b1b90de0da375885304eL34-R34) [[2]](diffhunk://#diff-22493077629b8aa6550146b10f1a3168687583b94df9b1b90de0da375885304eR115-R118)
- Updated the `rawData` to use the latest upgrade names (e.g., 'Fusaka', 'Pectra', 'Dencun', 'Shapella') and included new EIPs for these upgrades. [[1]](diffhunk://#diff-22493077629b8aa6550146b10f1a3168687583b94df9b1b90de0da375885304eL237-R269) [[2]](diffhunk://#diff-22493077629b8aa6550146b10f1a3168687583b94df9b1b90de0da375885304eL273-R281)
- Enhanced meta EIP mapping to support paired upgrade names and ensure meta EIPs are only counted/shown once per date, preferring execution layer upgrades. [[1]](diffhunk://#diff-22493077629b8aa6550146b10f1a3168687583b94df9b1b90de0da375885304eR168-R174) [[2]](diffhunk://#diff-22493077629b8aa6550146b10f1a3168687583b94df9b1b90de0da375885304eL388-R398) [[3]](diffhunk://#diff-22493077629b8aa6550146b10f1a3168687583b94df9b1b90de0da375885304eL402-R423) [[4]](diffhunk://#diff-22493077629b8aa6550146b10f1a3168687583b94df9b1b90de0da375885304eL942-R958) [[5]](diffhunk://#diff-22493077629b8aa6550146b10f1a3168687583b94df9b1b90de0da375885304eL951-R972)

**Tooltip and UI enhancements:**

- Improved tooltip logic to aggregate EIPs across all upgrades on the same date, display counts by category, and show detailed lists of non-core EIPs. [[1]](diffhunk://#diff-22493077629b8aa6550146b10f1a3168687583b94df9b1b90de0da375885304eL1097-R1149) [[2]](diffhunk://#diff-22493077629b8aa6550146b10f1a3168687583b94df9b1b90de0da375885304eR1327-R1361)
- Tooltip now displays paired upgrade names and descriptions when available, providing clearer context for users.

**Layout and component flexibility:**

- Updated the `ZoomableTimeline` component and its usage to support a flexible `height` prop, allowing it to fill its container and better align with the surrounding layout. [[1]](diffhunk://#diff-c8637f3754b11f6c67893935a7fbc381866355225cca7d4f75bbffb6ac3430feR15-R18) [[2]](diffhunk://#diff-c8637f3754b11f6c67893935a7fbc381866355225cca7d4f75bbffb6ac3430feL38-R39) [[3]](diffhunk://#diff-c8637f3754b11f6c67893935a7fbc381866355225cca7d4f75bbffb6ac3430feL49-R50) [[4]](diffhunk://#diff-ebcbb699c15bf29ab090e1b517cc942c88e1ffc0e0f0c54895a29ee85660a64dL2224-R2229) [[5]](diffhunk://#diff-ebcbb699c15bf29ab090e1b517cc942c88e1ffc0e0f0c54895a29ee85660a64dL2361-R2365)