### PR TITLE
Update reviewers list to use centralized helpers.REVIEWERS_LIST and adjust yearly data filtering logic  - Replaced hardcoded reviewers list in the ReviewTracker and renderCharts2 functions with helpers.REVIEWERS_LIST for consistency across components. - Modified the getYearlyData function to dynamically include data up to the current year, preventing future years from being inadvertently excluded.

### DIFF
--- a/src/pages/Reviewers/index.tsx
+++ b/src/pages/Reviewers/index.tsx
@@ -310,7 +310,9 @@ const ReviewTracker = () => {
     setCsvData(csv); 
   };
 
-  const reviewersList = ["nalepae", "SkandaBhat", "advaita-saha", "Marchhill", "bomanaps","daniellehrner"];
+  // Canonical reviewers list – keep in sync with helpers.REVIEWERS_LIST so
+  // leaderboard, charts, and CSVs all classify reviewers/editors the same way.
+  const reviewersList = helpers.REVIEWERS_LIST;
 
   const generateCSVData11 = () => {
     if (!selectedYear || !selectedMonth) {
@@ -1286,7 +1288,7 @@ const renderCharts = (
 
 const renderCharts2 = (data: PRData[], selectedYear: string | null, selectedMonth: string | null) => {
   // List of reviewers (others are editors)
-  const reviewersList = ["nalepae", "SkandaBhat", "advaita-saha", "Marchhill","bomanaps", "daniellehrner"];
+  const reviewersList = helpers.REVIEWERS_LIST;
 
   // ALWAYS use eipdata, ercdata, ripdata for consistency
   let dataToUse: PRData[];

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -165,10 +165,14 @@ export const getYearlyData = (
   data: PRData[],
   showReviewer: ShowReviewerType
 ): Record<string, number> => {
+  const currentYear = new Date().getFullYear();
+
   const yearlyData: Record<string, number> = data
     ?.filter((item) => {
       const itemYear = parseInt(item.monthYear.split('-')[0], 10);
-      return itemYear >= 2015 && itemYear <= 2025;
+      // Include data from 2015 up to the current year so that new
+      // years (e.g. 2026, 2027, ...) are not accidentally dropped.
+      return itemYear >= 2015 && itemYear <= currentYear;
     })
     ?.reduce((acc, item) => {
       if (showReviewer[item.reviewer]) {


### PR DESCRIPTION
This pull request improves consistency in how reviewers are classified across the application by centralizing the reviewers list and future-proofing yearly data calculations. The main changes are:

**Consistency in reviewer classification:**

- Replaced hardcoded reviewer lists in `src/pages/Reviewers/index.tsx` with the canonical `helpers.REVIEWERS_LIST` to ensure all features (leaderboard, charts, CSVs) use the same reviewer/editor classification. [[1]](diffhunk://#diff-8a07cdcc83a14a37aacdf7b914edf19d783beef499054b16ada6b9ada890ee4eL313-R315) [[2]](diffhunk://#diff-8a07cdcc83a14a37aacdf7b914edf19d783beef499054b16ada6b9ada890ee4eL1289-R1291)

**Data handling improvements:**

- Updated `getYearlyData` in `src/utils/helpers.ts` to use the current year dynamically instead of a hardcoded upper limit, ensuring new years are automatically included in data processing.