### PR TITLE
Handle indented markdown headings in TOC extraction

### DIFF
--- a/src/utils/toc.ts
+++ b/src/utils/toc.ts
@@ -19,12 +19,12 @@ export function extractHeadingsFromMarkdown(markdown: string) {
 
     if (inFence) return false;
 
-    return /^#{1,4}\s/.test(line);
+    return /^\s{0,3}#{1,4}\s/.test(line);
   });
 
   return headingLines.map(line => {
-    const depth = line.match(/^#+/)![0].length;
-    const text = line.replace(/^#+\s?/, '').trim();
+    const depth = line.match(/#{1,4}/)![0].length;
+    const text = line.replace(/^\s{0,3}#+\s?/, '').trim();
     const id = text
       .toLowerCase()
       .replace(/[^\w]+/g, '-')

--- a/tests/toc.test.ts
+++ b/tests/toc.test.ts
@@ -42,6 +42,19 @@ test('generates a slug id from heading text', () => {
   assert.equal(headings[0].id, 'my-heading');
 });
 
+test('handles headings with up to three leading spaces', () => {
+  const markdown = ['   # Heading 1', '  ## Heading 2', ' ### Heading 3'].join('\n');
+
+  const headings = extractHeadingsFromMarkdown(markdown);
+
+  assert.deepEqual(headings.map(heading => heading.depth), [1, 2, 3]);
+  assert.deepEqual(headings.map(heading => heading.text), [
+    'Heading 1',
+    'Heading 2',
+    'Heading 3',
+  ]);
+});
+
 test('ignores headings inside fenced code blocks', () => {
   const markdown = [
     '# Real Heading',


### PR DESCRIPTION
### Motivation
- The TOC extractor should recognize ATX headings that have up to three leading spaces, matching common Markdown practice.
- Tests should cover indented headings to prevent regressions.

### Description
- Update `src/utils/toc.ts` to detect headings with up to three leading spaces by changing the detection regex to `^\s{0,3}#{1,4}\s` and to compute depth with `/#{1,4}/` while trimming leading spaces with `/^\s{0,3}#+\s?/`.
- Add a unit test `handles headings with up to three leading spaces` to `tests/toc.test.ts` that verifies depths and text are extracted for indented headings.
- Modified files: `src/utils/toc.ts` and `tests/toc.test.ts`.

### Testing
- No automated tests were executed during this rollout.