### PR TITLE
docs: document test script in NEWCOMER_GUIDE 

### DIFF
--- a/docs/NEWCOMER_GUIDE.md
+++ b/docs/NEWCOMER_GUIDE.md
@@ -15,7 +15,7 @@ These files set up the app and build system:
   (core build, routing middleware, and deployment)
 
 - **Dependencies & scripts:**
-  `package.json` defines scripts (`dev`, `build`, `start`, `lint`, `create-admin`, `migrate-blogs`) and the dependency stack (React + Next.js + UI libs + charts + data tooling).
+  `package.json` defines scripts (`dev`, `build`, `start`, `lint`, `test`, `create-admin`, `migrate-blogs`) and the dependency stack (React + Next.js + UI libs + charts + data tooling).
 
 ---
 


### PR DESCRIPTION
### Motivation
- The `docs/NEWCOMER_GUIDE.md` scripts list was out-of-sync with `package.json` because it omitted the `test` script, which could confuse newcomers.

### Description
- Updated `docs/NEWCOMER_GUIDE.md` to include the `test` script in the `package.json` scripts list.

### Testing
- No automated tests were run because this is a documentation-only change.