### PR TITLE
Update chart headings for clarity in CategorySubcategoryChart and PRA…

### DIFF
--- a/src/components/CategorySubcategoryChart.tsx
+++ b/src/components/CategorySubcategoryChart.tsx
@@ -423,7 +423,7 @@ export default function CategorySubcategoryChart() {
       <CardHeader>
         <Flex align="center" justify="space-between" wrap="wrap" gap={4}>
           <Heading size="md" color={accentColor} mb={2} id="CategorySubcategoryChart">
-            Graph 3: Process × Participants (stacked)
+            Process × Participants (stacked)
             <CopyLink link="https://eipsinsight.com/Analytics#CategorySubcategoryChart" />
           </Heading>
           <Flex gap={2} wrap="wrap">

--- a/src/components/PrLabels.tsx
+++ b/src/components/PrLabels.tsx
@@ -594,7 +594,7 @@ export default function PRAnalyticsCard() {
       <CardHeader>
         <Flex align="center" justify="space-between" wrap="wrap" gap={4}>
           <Heading size="md" color={accentColor} mb={2} id="PrLabelsChart">
-            Graph 2: {REPOS.find(r => r.key === repoKey)?.label} &mdash; {labelSetOptions.find(o => o.key === labelSet)?.label}
+           {REPOS.find(r => r.key === repoKey)?.label} &mdash; {labelSetOptions.find(o => o.key === labelSet)?.label}
             <CopyLink link={`https://eipsinsight.com//Analytics#PrLabelsChart`} />
           </Heading>
           <Flex gap={3} align="center">


### PR DESCRIPTION
This pull request makes minor updates to the headings in two chart components to remove the "Graph X:" prefix, resulting in cleaner chart titles.

- UI Improvements:
  * [`src/components/CategorySubcategoryChart.tsx`](diffhunk://#diff-164dbaef5a33456e8cbbecc9479727f6eb0da0532e0edaa41a81d7eca36395e6L426-R426): Removed "Graph 3:" from the chart heading for a more concise title.
  * [`src/components/PrLabels.tsx`](diffhunk://#diff-fd1a13ca4f6801f46118a35ab86dee8e2a412779332e46bd4bc8293fb10a96f6L597-R597): Removed "Graph 2:" from the PR analytics chart heading for consistency and clarity.