### PR TITLE
Refine Description

### DIFF
--- a/src/components/CategorySubcategoryChart.tsx
+++ b/src/components/CategorySubcategoryChart.tsx
@@ -536,7 +536,7 @@ export default function CategorySubcategoryChart() {
           </Button>
           {showDescription && (
             <Box fontSize="sm" color={useColorModeValue("gray.600", "gray.400")}>
-              Same open PRs as Graph 1 Open and Graph 2. Toggle to put <strong>Process</strong> or <strong>Participants</strong> on the X-axis (the other is stacked). Sum of segments = open PR count for the month. <strong>Awaited</strong> = draft PRs (when Process is PR DRAFT and not stagnant). Vertical bar; one month per view. Legend is above the chart.
+              Open PRs by process type and participant status. Choose <strong>Process</strong> or <strong>Participants</strong> on the X-axis (the other is stacked). Sum of segments = total open PRs for the month. <strong>Awaited</strong> = draft PRs when process is PR DRAFT and not stagnant. One month per view; legend above the chart.
             </Box>
           )}
         </Flex>
@@ -549,7 +549,7 @@ export default function CategorySubcategoryChart() {
             </Text>
           ) : noDataAtAll ? (
             <Text color="gray.500" py={12} fontWeight="bold" fontSize="lg">
-              No category-subcategory data for this repo. Run populate-charts to fill the collection.
+              No open PRs by process/participants for this repo or period.
             </Text>
           ) : !hasDataForMonth ? (
             <Text color="gray.500" py={12} fontWeight="bold" fontSize="lg">
@@ -616,7 +616,7 @@ export default function CategorySubcategoryChart() {
                 </Menu>
               </Flex>
               <Text fontSize="xs" color={tableMutedColor} mb={3}>
-                Table uses the same data as the chart (Graph 3 API). For a per-PR list, use the Boards or EIP Board page.
+                Table shows the same counts as the chart. For a per-PR list with links, use the EIP Board or Boards page.
               </Text>
 
               <TableContainer

--- a/src/components/PrLabels.tsx
+++ b/src/components/PrLabels.tsx
@@ -653,7 +653,7 @@ export default function PRAnalyticsCard() {
           </Flex>
         </Flex>
         <Text fontSize="sm" color={useColorModeValue("gray.600", "gray.400")} mt={2}>
-          Same open PRs as Graph 1 Open. Toggle <strong>Process</strong> (category) or <strong>Participants</strong> (subcategory); sum of counts = Graph 1 Open per month. <strong>Awaited</strong> = draft PRs when Process is PR DRAFT and not stagnant.
+          Open PRs by <strong>Process</strong> type (e.g. Typo, NEW EIP, PR DRAFT) or by <strong>Participants</strong> status (e.g. Waiting on Editor, Awaited). Toggle the dropdown to switch. Sum of bars = total open PRs for that month. <strong>Awaited</strong> = draft PRs when process is PR DRAFT and not stagnant.
         </Text>
       </CardHeader>
       <CardBody>
@@ -705,11 +705,11 @@ export default function PRAnalyticsCard() {
           </Text>
           {selectedMonth && tableMonthTotal != null && (
             <Text fontSize="md" fontWeight="semibold" color={useColorModeValue('green.700', 'green.300')} mt={2}>
-              Table total for {formatMonthLabel(selectedMonth)} (matches eipboards): <Text as="span" color={accentColor}>{tableMonthTotal}</Text>
+              Table total for {formatMonthLabel(selectedMonth)} (filtered by selected labels): <Text as="span" color={accentColor}>{tableMonthTotal}</Text>
             </Text>
           )}
           <Text fontSize="xs" color={useColorModeValue('gray.600', 'gray.400')} mt={2}>
-            Chart, table (eipboards), and CSV all use the same <strong>snapshot</strong> data (hourly pre-aggregation). Counts match.
+            Chart, table, and CSV show the same open PRs for the selected month and labels.
           </Text>
         </Box>
         <Divider my={3} />


### PR DESCRIPTION
This pull request updates the descriptions and user-facing text for the category/subcategory charts and PR analytics card components to improve clarity and accuracy. The changes focus on making the explanations of chart data, table contents, and filtering behavior more precise and easier for users to understand.

**Improvements to chart and table descriptions:**

* Updated the chart description in `CategorySubcategoryChart` to clarify that open PRs are shown by process type and participant status, and refined the explanation of the "Awaited" category.
* Changed the table description in `CategorySubcategoryChart` to clearly state that the table shows the same counts as the chart and directs users to the EIP Board or Boards page for per-PR lists with links.

**Enhancements to empty state and filtering messages:**

* Revised the empty state message in `CategorySubcategoryChart` to indicate no open PRs by process/participants for the repo or period, instead of referencing missing category-subcategory data.
* Improved the chart description in `PRAnalyticsCard` to specify the types of process and participant statuses, how to toggle views, and the meaning of the "Awaited" category.
* Updated the table total and data source descriptions in `PRAnalyticsCard` to clarify filtering by selected labels and that chart, table, and CSV all show the same open PRs for the selected month and labels.