### PR TITLE
Enhance tooltip visibility across components by setting zIndex to 10001

### DIFF
--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -12,13 +12,19 @@ const theme = extendTheme({
     useSystemColorMode: false,
   },
   styles: {
-
     global: (props: StyleFunctionProps) => ({
       body: {
         bg: props.colorMode === 'light' ? '#ffffff' : '#000000',
         color: props.colorMode === 'dark' ? 'whiteAlpha.900' : 'gray.800',
       },
     }),
+  },
+  components: {
+    Tooltip: {
+      baseStyle: {
+        zIndex: 10001, // above floaters (z-index 2000) so tooltips show on top
+      },
+    },
   },
 });
 

--- a/src/components/BookmarkFloater.tsx
+++ b/src/components/BookmarkFloater.tsx
@@ -39,7 +39,7 @@ import {
           zIndex="1000"
           borderRadius="50%"
         >
-          <Tooltip label="View Bookmarks" placement="left">
+          <Tooltip label="View Bookmarks" placement="left" zIndex={10001}>
             <IconButton
               aria-label="Bookmarks"
               icon={<FiBookmark />}

--- a/src/components/FloatingContributionIcon.tsx
+++ b/src/components/FloatingContributionIcon.tsx
@@ -50,7 +50,7 @@ const FloatingContributionIcon = () => {
       zIndex="1000"
       borderRadius="50%"
     >
-      <Tooltip label="View in Github!" placement="left">
+      <Tooltip label="View in Github!" placement="left" zIndex={10001}>
         <IconButton
           aria-label="Contribute"
           icon={<FaGithub />}

--- a/src/components/SubscriptionFloater.tsx
+++ b/src/components/SubscriptionFloater.tsx
@@ -106,7 +106,7 @@ const SubscriptionFloater = () => {
         zIndex="1000"
         borderRadius="50%"
       >
-        <Tooltip label="View Subscription" placement="left">
+        <Tooltip label="View Subscription" placement="left" zIndex={10001}>
           <IconButton
             aria-label="Subscription"
             icon={<FiAward />}


### PR DESCRIPTION
This pull request addresses tooltip visibility issues by ensuring that tooltips always appear above floating action buttons. The changes involve setting a higher z-index for tooltips both globally in the Chakra UI theme and locally in tooltip components.

**Tooltip visibility improvements:**

* Set a global z-index of 10001 for all `Tooltip` components in the Chakra UI theme to ensure tooltips display above floating elements (`providers.tsx`).
* Explicitly set `zIndex={10001}` on individual `Tooltip` components in `BookmarkFloater`, `FloatingContributionIcon`, and `SubscriptionFloater` to reinforce the correct stacking order. (`BookmarkFloater.tsx`, `FloatingContributionIcon.tsx`, `SubscriptionFloater.tsx`) [[1]](diffhunk://#diff-ec6eff2071d7ad3dd86431ef672eb38de775d0df1b8ea655dc1d848e01d8ad23L42-R42) [[2]](diffhunk://#diff-f9b50622bb79bae8bc9904ff725b851d9449e34dcde5c073f4a1aebcd26c48c6L53-R53) [[3]](diffhunk://#diff-acd9cf23a45743145687bafc09938baae39b7b8db0de091ea5bed2c4a26f31d1L109-R109)