### PR TITLE
Update EipBoardsPage sorting logic and rename column for clarity

### DIFF
--- a/src/pages/boardsnew/index.tsx
+++ b/src/pages/boardsnew/index.tsx
@@ -340,7 +340,9 @@ export default function EipBoardsPage() {
       list = list.filter((r) => r.waitDays != null && r.waitDays >= min && r.waitDays <= max);
     }
     return [...list].sort((a, b) => {
-      if (b.attentionScore !== a.attentionScore) return b.attentionScore - a.attentionScore;
+      const waitA = a.waitDays ?? -1;
+      const waitB = b.waitDays ?? -1;
+      if (waitB !== waitA) return waitB - waitA;
       const da = a.CreatedAt ? new Date(a.CreatedAt).getTime() : 0;
       const db = b.CreatedAt ? new Date(b.CreatedAt).getTime() : 0;
       return db - da;
@@ -563,7 +565,7 @@ export default function EipBoardsPage() {
               </Text>
               <Flex justify="space-between" align="center" flexWrap="wrap" gap={4}>
                 <HStack>
-                  <Text fontWeight="600" fontSize="sm">Status</Text>
+                  <Text fontWeight="600" fontSize="sm">PR Status</Text>
                   <Select
                     value={selectedSubcategory}
                     onChange={(e) => { setSelectedSubcategory(e.target.value); setWaitPresetDays(null); setPage(1); }}
@@ -724,7 +726,7 @@ export default function EipBoardsPage() {
                     <Th fontWeight="700">Created</Th>
                     <Th fontWeight="700">Wait</Th>
                     <Th fontWeight="700">Process</Th>
-                    <Th fontWeight="700">Status</Th>
+                    <Th fontWeight="700">PR Status</Th>
                     <Th fontWeight="700">Labels</Th>
                     <Th fontWeight="700">Link</Th>
                   </Tr>


### PR DESCRIPTION
This pull request introduces minor updates to `EipBoardsPage` in `src/pages/boardsnew/index.tsx`, primarily improving sorting logic and clarifying column labels for pull request status.

Sorting improvements:

* Changed the sorting logic to prioritize `waitDays` instead of `attentionScore`, ensuring items are ordered by their waiting period for better relevance.

UI/Label clarity:

* Updated the label "Status" to "PR Status" in both the filter dropdown and the table header to make it clear that the status refers specifically to pull requests. [[1]](diffhunk://#diff-b1d3217c736146960474678d63c43183878646370615cea375965cebf976ccd9L566-R568) [[2]](diffhunk://#diff-b1d3217c736146960474678d63c43183878646370615cea375965cebf976ccd9L727-R729)