### PR TITLE
Recent Changes re;ated to dashboard graphs

### DIFF
--- a/src/components/AllChart2.tsx
+++ b/src/components/AllChart2.tsx
@@ -158,7 +158,7 @@ const AllChart: React.FC<ChartProps> = ({ type }) => {
   }
 
   interface TransformedData2 {
-    status: string;
+    category: string;
     year: number;
     value: number;
   }
@@ -170,91 +170,92 @@ const AllChart: React.FC<ChartProps> = ({ type }) => {
     ...(data?.rip || []),
   ];
 
-  const transformedData = allBuckets.reduce<TransformedData[]>((acc, bucket) => {
-    const year = bucket.year;
+  // To avoid double-counting the same EIP multiple times within the same year,
+  // deduplicate by (year, eip). This ensures totals match unique EIP counts shown elsewhere.
+  const seenYearEip = new Set<string>();
+  const transformedData = [] as TransformedData[];
+  const transformedData2 = [] as TransformedData2[];
 
+  allBuckets.forEach((bucket) => {
+    const year = bucket.year;
     bucket.statusChanges.forEach((sc) => {
+      const yearEipKey = `${year}|${sc.eip}`;
+      if (seenYearEip.has(yearEipKey)) return; // skip duplicate status changes for same EIP in same year
+      seenYearEip.add(yearEipKey);
+
       const baseCategory =
         bucket.repo === "rip" ? "RIPs" : getCat(sc.eipCategory || "");
 
-      const existingEntry = acc.find(
+      const catEntry = transformedData.find(
         (entry) => entry.year === year && entry.category === baseCategory
       );
-
-      if (existingEntry) {
-        existingEntry.value += 1;
+      if (catEntry) {
+        catEntry.value += 1;
       } else {
-        acc.push({
+        transformedData.push({
           category: baseCategory,
           year,
           value: 1,
         });
       }
-    });
 
-    return acc;
-  }, []);
-
-  const transformedData2 = allBuckets.reduce<TransformedData[]>((acc, bucket) => {
-    const year = bucket.year;
-
-    bucket.statusChanges.forEach((sc) => {
       const status = getStatus(sc.lastStatus);
-
-      const existingEntry = acc.find(
-        (entry) => entry.year === year && entry.category === status
+      // normalize status into the same shape as transformedData (use category field)
+      const statusCategory = status;
+      const statusEntry = transformedData2.find(
+        (entry) => entry.year === year && entry.category === statusCategory
       );
-
-      if (existingEntry) {
-        existingEntry.value += 1;
+      if (statusEntry) {
+        statusEntry.value += 1;
       } else {
-        acc.push({
-          category: status,
+        transformedData2.push({
+          category: statusCategory,
           year,
           value: 1,
-        });
+        } as any);
       }
     });
-
-    return acc;
-  }, []);
+  });
 
   // Prepare CSV data whenever API data changes
   React.useEffect(() => {
-    const rows: any[] = [];
-    let srNumber = 1;
+    // Build a map of unique EIPs -> choose the most recent year entry for that EIP
+    const eipMap: Record<
+      string,
+      { year: number; repo: string; sc: FinalStatusChange }
+    > = {};
 
-    // Sort all buckets by year, then by repo, then by EIP number
-    const sortedBuckets = [...allBuckets].sort((a, b) => {
-      if (a.year !== b.year) return a.year - b.year;
-      const repoOrder = { eip: 1, erc: 2, rip: 3 };
-      if (repoOrder[a.repo] !== repoOrder[b.repo]) {
-        return (repoOrder[a.repo] || 99) - (repoOrder[b.repo] || 99);
-      }
-      // Sort by EIP number within same year and repo
-      const aEipNum = parseInt(a.statusChanges[0]?.eip.replace('EIP-', '') || '0');
-      const bEipNum = parseInt(b.statusChanges[0]?.eip.replace('EIP-', '') || '0');
-      return aEipNum - bEipNum;
-    });
+    const repoOrder: Record<string, number> = { eip: 1, erc: 2, rip: 3 };
 
-    sortedBuckets.forEach((bucket) => {
+    allBuckets.forEach((bucket) => {
       const year = bucket.year;
       const repo = bucket.repo;
-
-      // Sort statusChanges by EIP number
-      const sortedStatusChanges = [...bucket.statusChanges].sort((a, b) => {
-        const aNum = parseInt(a.eip.replace('EIP-', '') || '0');
-        const bNum = parseInt(b.eip.replace('EIP-', '') || '0');
-        return aNum - bNum;
+      bucket.statusChanges.forEach((sc) => {
+        const key = sc.eip;
+        const existing = eipMap[key];
+        if (!existing) {
+          eipMap[key] = { year, repo, sc };
+        } else {
+          // prefer the entry with later year; if same year prefer repo order (eip > erc > rip)
+          if (
+            year > existing.year ||
+            (year === existing.year &&
+              (repoOrder[repo] || 99) < (repoOrder[existing.repo] || 99))
+          ) {
+            eipMap[key] = { year, repo, sc };
+          }
+        }
       });
+    });
 
-      sortedStatusChanges.forEach((sc) => {
-        const eipNumber = sc.eip.replace('EIP-', '');
-        const normalizedCategory = bucket.repo === "rip" ? "RIPs" : getCat(sc.eipCategory || "");
+    // Convert map to rows and sort by year, repo, eip number
+    const rows = Object.values(eipMap)
+      .map(({ year, repo, sc }, idx) => {
+        const eipNumber = sc.eip.replace("EIP-", "");
+        const normalizedCategory = repo === "rip" ? "RIPs" : getCat(sc.eipCategory || "");
         const normalizedStatus = getStatus(sc.lastStatus);
-        
-        rows.push({
-          "SR No.": srNumber++,
+        return {
+          "SR No.": idx + 1,
           Year: year,
           Repo: repo.toUpperCase(),
           EIP: sc.eip,
@@ -265,9 +266,17 @@ const AllChart: React.FC<ChartProps> = ({ type }) => {
           "Final Status": normalizedStatus,
           "Original Status": sc.lastStatus,
           "EIP Link": `https://eipsinsight.com/eips/eip-${eipNumber}`,
-        });
+        };
+      })
+      .sort((a: any, b: any) => {
+        if (a.Year !== b.Year) return a.Year - b.Year;
+        const orderA = repoOrder[a.Repo.toLowerCase()] || 99;
+        const orderB = repoOrder[b.Repo.toLowerCase()] || 99;
+        if (orderA !== orderB) return orderA - orderB;
+        const aNum = parseInt(a["EIP Number"] || "0");
+        const bNum = parseInt(b["EIP Number"] || "0");
+        return aNum - bNum;
       });
-    });
 
     setCsvData(rows);
   }, [JSON.stringify(data)]);
@@ -279,22 +288,29 @@ const AllChart: React.FC<ChartProps> = ({ type }) => {
     }
   );
 
-  const transformedData3 =
-    chart === "status" ? transformedData2 : transformedData;
+  const transformedData3 = chart === "status" ? transformedData2 : transformedData;
 
-  const totalCount = transformedData3.reduce(
-    (sum, item) => sum + (item?.value || 0),
-    0
-  );
+  // Total unique EIPs across all buckets (deduplicated across years)
+  const uniqueEips = new Set<string>();
+  allBuckets.forEach((bucket) => {
+    bucket.statusChanges.forEach((sc) => uniqueEips.add(sc.eip));
+  });
+  const totalCount = uniqueEips.size;
 
-  // Calculate year totals for tooltip
-  const yearTotals = transformedData3.reduce((acc, item) => {
-    if (!acc[item.year]) {
-      acc[item.year] = 0;
-    }
-    acc[item.year] += item.value;
+  // Calculate year totals (unique EIPs per year) for tooltip
+  const yearTotals = allBuckets.reduce((acc, bucket) => {
+    const year = bucket.year;
+    if (!acc[year]) acc[year] = new Set<string>();
+    bucket.statusChanges.forEach((sc) => {
+      acc[year].add(sc.eip);
+    });
     return acc;
-  }, {} as Record<number, number>);
+  }, {} as Record<number, Set<string>>);
+  // Convert sets to counts
+  const yearTotalsCount: Record<number, number> = {};
+  Object.keys(yearTotals).forEach((y) => {
+    yearTotalsCount[Number(y)] = yearTotals[Number(y)].size;
+  });
 
   // Generate dynamic color function
   const getColorForCategory = (category: string, index: number) => {
@@ -337,7 +353,7 @@ const AllChart: React.FC<ChartProps> = ({ type }) => {
       customContent: (title: string, items: any[]) => {
         if (!items || items.length === 0) return '';
         const year = items[0]?.data?.year || title;
-        const yearTotal = yearTotals[year] || 0;
+        const yearTotal = yearTotalsCount[year] || 0;
         
         let html = `<div style="padding: 12px; background: ${tooltipBg}; color: ${tooltipText}; border-radius: 8px; box-shadow: 0 4px 12px rgba(0,0,0,0.15); min-width: 220px; border: 1px solid ${tooltipBorder};">`;
         html += `<div style="font-weight: 700; margin-bottom: 10px; padding-bottom: 6px; border-bottom: 2px solid ${tooltipBorder}; font-size: 14px; color: #30A0E0;">Year ${year} - Total: <strong>${yearTotal}</strong></div>`;

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -155,6 +155,8 @@ const Dashboard = () => {
   console.log("unique eip1:", uniqueeip);
   const uniqueeip2 = allData.filter((item) => item.status === " ");
   console.log("unique eip2:", uniqueeip2);
+  // Unique EIP count (deduplicated by EIP identifier) to keep dashboard totals consistent
+  const uniqueEipCount = new Set(allData.map((item) => item.eip)).size;
 const textColor = useColorModeValue("gray.800", "gray.200");
 const linkColor = useColorModeValue("blue.600", "blue.300");
 
@@ -988,7 +990,7 @@ const linkColor = useColorModeValue("blue.600", "blue.300");
                         paddingBottom={6}
                         padding={2}
                       >
-                        {`Category - [${allData.length}]`}
+                      {`Category - [${uniqueEipCount}]`}
                       </Text>
                     </NextLink>
                     <DashboardDonut2 dataset={data} />
@@ -1026,7 +1028,7 @@ const linkColor = useColorModeValue("blue.600", "blue.300");
                         paddingBottom={6}
                         padding={2}
                       >
-                        {`Status - [${allData.length}]`}
+                        {`Status - [${uniqueEipCount}]`}
                       </Text>
                     </NextLink>
                     <DashboardDonut dataset={data} />


### PR DESCRIPTION
This pull request updates the EIP dashboard and chart components to ensure that all total counts (overall and per year) reflect unique EIPs, rather than counting duplicates. This change improves the accuracy and consistency of the displayed totals across the dashboard and charts. Additionally, there are some minor code cleanups for consistency.

**Data accuracy and consistency improvements:**

* The total count and per-year totals in `AllChart2.tsx` are now calculated using unique EIP identifiers, ensuring deduplication across years and buckets. This affects both the main chart total and tooltip year totals. [[1]](diffhunk://#diff-67cd3d6d5ebbc3eecf428c5f41f719091152386b7181458deee7d1fea8dd63d6L282-R304) [[2]](diffhunk://#diff-67cd3d6d5ebbc3eecf428c5f41f719091152386b7181458deee7d1fea8dd63d6L340-R347)
* The dashboard summary counts for Category and Status now display the count of unique EIPs instead of the total number of data rows, aligning the dashboard with the updated chart logic. [[1]](diffhunk://#diff-55f0972bb4b7296662837848de58d3f196d3d2626f9bc3002cf1f3d782952b28R158-R159) [[2]](diffhunk://#diff-55f0972bb4b7296662837848de58d3f196d3d2626f9bc3002cf1f3d782952b28L991-R993) [[3]](diffhunk://#diff-55f0972bb4b7296662837848de58d3f196d3d2626f9bc3002cf1f3d782952b28L1029-R1031)

**Code consistency and cleanup:**

* Updated field names and comments in `AllChart2.tsx` for clarity (e.g., renaming `status` to `category` in the `TransformedData2` interface and clarifying CSV data preparation comments). [[1]](diffhunk://#diff-67cd3d6d5ebbc3eecf428c5f41f719091152386b7181458deee7d1fea8dd63d6L161-R161) [[2]](diffhunk://#diff-67cd3d6d5ebbc3eecf428c5f41f719091152386b7181458deee7d1fea8dd63d6L222-R222)
* Standardized string quoting style for EIP number parsing and replacement in multiple places within `AllChart2.tsx`. [[1]](diffhunk://#diff-67cd3d6d5ebbc3eecf428c5f41f719091152386b7181458deee7d1fea8dd63d6L235-R236) [[2]](diffhunk://#diff-67cd3d6d5ebbc3eecf428c5f41f719091152386b7181458deee7d1fea8dd63d6L246-R252)