### PR TITLE
Refractor All Chart 2

### DIFF
--- a/src/components/AllChart2.tsx
+++ b/src/components/AllChart2.tsx
@@ -279,29 +279,19 @@ const AllChart: React.FC<ChartProps> = ({ type }) => {
     }
   );
 
+  // Total raw entries across transformed data (counts every status-change row)
   const transformedData3 = chart === "status" ? transformedData2 : transformedData;
 
-  // Total unique EIPs across all buckets (deduplicated across years)
-  const uniqueEips = new Set<string>();
-  allBuckets.forEach((bucket) => {
-    bucket.statusChanges.forEach((sc) => uniqueEips.add(sc.eip));
-  });
-  const totalCount = uniqueEips.size;
+  const totalCount = transformedData3.reduce(
+    (sum, item) => sum + (item?.value || 0),
+    0
+  );
 
-  // Calculate year totals (unique EIPs per year) for tooltip
-  const yearTotals = allBuckets.reduce((acc, bucket) => {
-    const year = bucket.year;
-    if (!acc[year]) acc[year] = new Set<string>();
-    bucket.statusChanges.forEach((sc) => {
-      acc[year].add(sc.eip);
-    });
+  // Calculate year totals (raw counts per year) for tooltip
+  const yearTotalsCount = transformedData3.reduce((acc, item) => {
+    acc[item.year] = (acc[item.year] || 0) + item.value;
     return acc;
-  }, {} as Record<number, Set<string>>);
-  // Convert sets to counts
-  const yearTotalsCount: Record<number, number> = {};
-  Object.keys(yearTotals).forEach((y) => {
-    yearTotalsCount[Number(y)] = yearTotals[Number(y)].size;
-  });
+  }, {} as Record<number, number>);
 
   // Generate dynamic color function
   const getColorForCategory = (category: string, index: number) => {

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -155,8 +155,8 @@ const Dashboard = () => {
   console.log("unique eip1:", uniqueeip);
   const uniqueeip2 = allData.filter((item) => item.status === " ");
   console.log("unique eip2:", uniqueeip2);
-  // Unique EIP count (deduplicated by EIP identifier) to keep dashboard totals consistent
-  const uniqueEipCount = new Set(allData.map((item) => item.eip)).size;
+  // Raw entry count (includes status-change rows)
+  const rawEntryCount = allData.length;
 const textColor = useColorModeValue("gray.800", "gray.200");
 const linkColor = useColorModeValue("blue.600", "blue.300");
 
@@ -990,7 +990,7 @@ const linkColor = useColorModeValue("blue.600", "blue.300");
                         paddingBottom={6}
                         padding={2}
                       >
-                      {`Category - [${uniqueEipCount}]`}
+                      {`Category - [${rawEntryCount}]`}
                       </Text>
                     </NextLink>
                     <DashboardDonut2 dataset={data} />
@@ -1028,7 +1028,7 @@ const linkColor = useColorModeValue("blue.600", "blue.300");
                         paddingBottom={6}
                         padding={2}
                       >
-                        {`Status - [${uniqueEipCount}]`}
+                        {`Status - [${rawEntryCount}]`}
                       </Text>
                     </NextLink>
                     <DashboardDonut dataset={data} />


### PR DESCRIPTION
This pull request updates how totals are calculated and displayed in the dashboard and chart components. The main change is shifting from counting unique EIP identifiers to counting all raw entries (including status-change rows), which affects both the logic and the UI labels. This ensures the displayed totals reflect the actual number of data rows rather than deduplicated EIPs.

Totals calculation changes:

* In `src/components/AllChart2.tsx`, the total count and year totals are now calculated based on raw entry counts from `transformedData3`, instead of deduplicated EIP identifiers.
* In `src/components/Dashboard.tsx`, the dashboard switches from using a unique EIP count to a raw entry count for its main total.

UI updates:

* The dashboard labels for "Category" and "Status" now show the raw entry count instead of the unique EIP count, updating the displayed numbers to match the new calculation logic. [[1]](diffhunk://#diff-55f0972bb4b7296662837848de58d3f196d3d2626f9bc3002cf1f3d782952b28L993-R993) [[2]](diffhunk://#diff-55f0972bb4b7296662837848de58d3f196d3d2626f9bc3002cf1f3d782952b28L1031-R1031)