### PR TITLE
fix: Update process labels and normalization logic to replace "Other" with "Content Edit" across components

### DIFF
--- a/src/components/CategorySubcategoryChart.tsx
+++ b/src/components/CategorySubcategoryChart.tsx
@@ -44,7 +44,7 @@ const REPOS = [
 ];
 
 // Graph 3: Process × Participants. type = "Process|Participants". Sum per month = Graph 1 Open.
-const PROCESS_ORDER = ["PR DRAFT", "Typo", "NEW EIP", "Website", "EIP-1", "Tooling", "Status Change", "Other"];
+const PROCESS_ORDER = ["PR DRAFT", "Typo", "NEW EIP", "Website", "EIP-1", "Tooling", "Status Change", "Content Edit"];
 const PARTICIPANTS_ORDER = ["Waiting on Editor", "Waiting on Author", "Stagnant", "Awaited", "Misc"];
 const PARTICIPANTS_COLORS: Record<string, string> = {
   "Waiting on Editor": "#6366f1",
@@ -61,7 +61,7 @@ const PROCESS_COLORS: Record<string, string> = {
   "EIP-1": "#ec4899",
   Tooling: "#14b8a6",
   "Status Change": "#ef4444",
-  Other: "#64748b",
+  "Content Edit": "#64748b",
 };
 
 /** Normalize API category to Graph 2 Process values */
@@ -74,8 +74,8 @@ function normalizeCategoryToPrLabels(cat: string): string {
   if (/^EIP-?1$/i.test(c)) return "EIP-1";
   if (/^Tooling$/i.test(c)) return "Tooling";
   if (/^Status\s*Change$/i.test(c)) return "Status Change";
-  if (/^Other$/i.test(c)) return "Other";
-  return "Other";
+  if (/^Other$/i.test(c)) return "Content Edit";
+  return "Content Edit";
 }
 
 /** Normalize API subcategory to Participants. Doc: AWAITED, Waiting on Editor, Waiting on Author, Stagnant, Misc. Graph 2 may store "Editor Review" from e-review label. */

--- a/src/components/PrLabels.tsx
+++ b/src/components/PrLabels.tsx
@@ -99,7 +99,7 @@ const PROCESS_LABELS: LabelSpec[] = [
   { value: "EIP-1", label: "EIP-1", color: "#8b5cf6" },             // violet → special / foundational
   { value: "Tooling", label: "Tooling", color: "#14b8a6" },         // teal → engineering / infra feel
   { value: "Status Change", label: "Status Change", color: "#f97316" }, // orange → action / transition
-  { value: "Other", label: "Other", color: "#64748b" },             // muted slate → miscellaneous
+  { value: "Content Edit", label: "Content Edit", color: "#64748b" },             // muted slate → miscellaneous
 ];
 
 // Graph 2: Participants (subcategory); Awaited = draft PRs when Process is PR DRAFT and not stagnant; empty/unknown → Misc
@@ -146,7 +146,7 @@ function labelsToProcess(labelsStr: string, repo: string, isPrDraft?: boolean): 
   if (labels.some((l) => /website|r-website/i.test(l))) return "Website";
   if (labels.some((l) => /eip-?1|EIP-?1/i.test(l))) return "EIP-1";
   if (labels.some((l) => /tooling|r-ci|r-process/i.test(l))) return "Tooling";
-  return "Other";
+  return "Content Edit";
 }
 // Graph 2 Participants: match backend deriveSubcategory (boards) so chart fallback and CSV derivation align
 function labelsToParticipants(labelsStr: string, _process: string, isPrDraft?: boolean): string {
@@ -173,8 +173,8 @@ function normalizeProcessTypeFromApi(type: string): string {
   if (/^EIP-?1$/i.test(t)) return "EIP-1";
   if (t === "Tooling") return "Tooling";
   if (/^Status\s*Change$/i.test(t)) return "Status Change";
-  if (t === "Other") return "Other";
-  return t || "Other";
+  if (t === "Other") return "Content Edit";
+  return t || "Content Edit";
 }
 
 /** Normalize Graph 2b API type (subcategory) to display: e.g. "AWAITED" → "Awaited". Chart doc type = subcategory name. */

--- a/src/pages/boardsnew/index.tsx
+++ b/src/pages/boardsnew/index.tsx
@@ -69,8 +69,8 @@ function normalizeProcess(p: string | undefined): string {
   if (/^EIP-?1$/i.test(t)) return "EIP-1";
   if (t === "Tooling") return "Tooling";
   if (/^Status\s*Change$/i.test(t)) return "Status Change";
-  if (t === "Other") return "Other";
-  return t || "Other";
+  if (t === "Other") return "Content Edit";
+  return t || "Content Edit";
 }
 
 function normalizeParticipants(s: string | undefined): string {
@@ -84,15 +84,16 @@ function normalizeParticipants(s: string | undefined): string {
   return t || "Misc";
 }
 
-const PROCESS_ORDER = ["PR DRAFT", "Typo", "NEW EIP", "Website", "EIP-1", "Tooling", "Status Change", "Other"];
+const PROCESS_ORDER = ["PR DRAFT", "Typo", "NEW EIP", "Status Change", "Website", "Tooling", "EIP-1", "Content Edit", "Other"];
 const PROCESS_COLORS: Record<string, string> = {
   "PR DRAFT": "purple",
   Typo: "green",
   "NEW EIP": "orange",
-  Website: "cyan",
-  "EIP-1": "pink",
-  Tooling: "teal",
   "Status Change": "red",
+  Website: "cyan",
+  Tooling: "teal",
+  "EIP-1": "pink",
+  "Content Edit": "yellow",
   Other: "gray",
 };
 const PARTICIPANT_COLORS: Record<string, string> = {


### PR DESCRIPTION
This pull request updates the handling of the "Other" process category throughout the codebase, replacing it with "Content Edit" for improved clarity and consistency. The changes affect normalization functions, chart ordering, color assignments, and label specifications across multiple files.

**Process category normalization and mapping:**

* All normalization functions now map "Other" to "Content Edit", ensuring consistent labeling and display across charts and API responses (`src/components/CategorySubcategoryChart.tsx`, `src/components/PrLabels.tsx`, `src/pages/boardsnew/index.tsx`). [[1]](diffhunk://#diff-164dbaef5a33456e8cbbecc9479727f6eb0da0532e0edaa41a81d7eca36395e6L77-R78) [[2]](diffhunk://#diff-fd1a13ca4f6801f46118a35ab86dee8e2a412779332e46bd4bc8293fb10a96f6L176-R177) [[3]](diffhunk://#diff-b1d3217c736146960474678d63c43183878646370615cea375965cebf976ccd9L72-R73)

**Chart and label configuration:**

* The `PROCESS_ORDER` arrays in chart components and board pages have been updated to include "Content Edit" instead of "Other", and in some cases, both are present for backward compatibility (`src/components/CategorySubcategoryChart.tsx`, `src/pages/boardsnew/index.tsx`). [[1]](diffhunk://#diff-164dbaef5a33456e8cbbecc9479727f6eb0da0532e0edaa41a81d7eca36395e6L47-R47) [[2]](diffhunk://#diff-b1d3217c736146960474678d63c43183878646370615cea375965cebf976ccd9L87-R96)
* The `PROCESS_COLORS` and `PROCESS_LABELS` mappings now assign the color slate/gray/yellow to "Content Edit", replacing the previous assignment to "Other" (`src/components/CategorySubcategoryChart.tsx`, `src/components/PrLabels.tsx`, `src/pages/boardsnew/index.tsx`). [[1]](diffhunk://#diff-164dbaef5a33456e8cbbecc9479727f6eb0da0532e0edaa41a81d7eca36395e6L64-R64) [[2]](diffhunk://#diff-fd1a13ca4f6801f46118a35ab86dee8e2a412779332e46bd4bc8293fb10a96f6L102-R102) [[3]](diffhunk://#diff-b1d3217c736146960474678d63c43183878646370615cea375965cebf976ccd9L87-R96)

**Label derivation logic:**

* Functions that derive process labels from PR labels or API types now return "Content Edit" instead of "Other" as the fallback or when matching the "Other" category (`src/components/PrLabels.tsx`).

These changes ensure that "Content Edit" is used as the canonical miscellaneous process category throughout the application, improving clarity for users and maintainers.