### PR TITLE
chore: Add ads.txt for Google AdSense.

### DIFF
--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-1430925999720527, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
This pull request adds a new entry to the `ads.txt` file to authorize a Google advertising publisher.

Ad platform authorization:

* Added a line to `ads.txt` to authorize `pub-1430925999720527` as a direct publisher with Google.