### PR TITLE
Refactor URL path and filenames from 'boardsnew' to 'boards'

### DIFF
--- a/src/components/CategorySubcategoryChart.tsx
+++ b/src/components/CategorySubcategoryChart.tsx
@@ -804,7 +804,7 @@ export default function CategorySubcategoryChart() {
                         const sr = (tablePage - 1) * TABLE_PAGE_SIZE + idx + 1;
                         const processColor = processBadgeColor(row.Process);
                         const partColor = participantsBadgeColor(row.Participants);
-                        const viewPrsUrl = `/boardsnew?month=${selectedMonthYear}&process=${encodeURIComponent(row.Process)}&participants=${encodeURIComponent(row.Participants)}`;
+                        const viewPrsUrl = `/boards?month=${selectedMonthYear}&process=${encodeURIComponent(row.Process)}&participants=${encodeURIComponent(row.Participants)}`;
                         return (
                           <Tr key={`${row.Process}-${row.Participants}-${sr}`} _hover={{ bg: tableRowHoverBg }}>
                             <Td fontWeight="semibold" color={tableMutedColor}>

--- a/src/pages/boards/index.tsx
+++ b/src/pages/boards/index.tsx
@@ -239,7 +239,7 @@ export default function EipBoardsPage() {
       params.set("process", selectedCategories.map((p) => encodeURIComponent(p)).join(","));
     }
     const queryString = params.toString();
-    const newUrl = queryString ? `/boardsnew?${queryString}` : "/boardsnew";
+    const newUrl = queryString ? `/boards?${queryString}` : "/boards";
     if (router.asPath !== newUrl) {
       router.replace(newUrl, undefined, { shallow: true });
     }
@@ -408,7 +408,7 @@ export default function EipBoardsPage() {
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = `boardsnew_${activeTab}_${selectedMonth}.csv`;
+    a.download = `boards_${activeTab}_${selectedMonth}.csv`;
     a.click();
     URL.revokeObjectURL(url);
     toast({ title: "CSV downloaded", status: "success", duration: 2000, isClosable: true });
@@ -421,7 +421,7 @@ export default function EipBoardsPage() {
     if (selectedCategories.length > 0 && selectedCategories.length < PROCESS_ORDER.length) {
       params.set("process", selectedCategories.map((p) => encodeURIComponent(p)).join(","));
     }
-    const url = `${typeof window !== "undefined" ? window.location.origin : ""}/boardsnew?${params.toString()}`;
+    const url = `${typeof window !== "undefined" ? window.location.origin : ""}/boards?${params.toString()}`;
     navigator.clipboard.writeText(url).then(() => {
       toast({ title: "Link copied to clipboard", status: "success", duration: 2000, isClosable: true });
     });


### PR DESCRIPTION
This pull request standardizes the naming convention for the "boards" feature by renaming all references from `boardsnew` to `boards` across the application. These changes ensure consistency in URLs, file downloads, and clipboard sharing.

**Boards feature renaming:**

* Updated the URL for viewing pull requests in the `CategorySubcategoryChart` component from `/boardsnew` to `/boards`.
* Changed the navigation URL in the `EipBoardsPage` page when updating filters, replacing `/boardsnew` with `/boards`.
* Updated the CSV download filename to use the new `boards` naming convention instead of `boardsnew`.
* Changed the URL copied to the clipboard for sharing filtered boards, replacing `/boardsnew` with `/boards`.