### PR TITLE
Implement token-based unsubscribe links and integrate NextAuth

### DIFF
--- a/docs/SUBSCRIPTIONS_FLOW.md
+++ b/docs/SUBSCRIPTIONS_FLOW.md
@@ -1,0 +1,509 @@
+# EIPs Insight Subscription Flow
+
+This document explains how subscriptions work in this repo end to end:
+
+- where users subscribe,
+- which APIs are called,
+- what gets stored in MongoDB,
+- how update emails are generated,
+- how unsubscribe works,
+- and what the current design intentionally does not support.
+
+## Purpose
+
+The subscription system lets a signed-in user follow a specific:
+
+- `EIP`
+- `ERC`
+- `RIP`
+
+and receive email notifications when the tracked proposal file changes.
+
+The system is proposal-specific. It is not a global "subscribe to all EIPs" system.
+
+## High-Level Flow
+
+1. A user opens an individual proposal page such as `/eips/[eip-number]`.
+2. The page shows a subscription button.
+3. The button checks whether the current signed-in user is already subscribed.
+4. If the user subscribes, the frontend calls `POST /api/subscribe`.
+5. The API stores a row in MongoDB `subscriptions`.
+6. A confirmation email is sent immediately.
+7. Later, the sync job scans tracked proposal files for new commits.
+8. If matching changes are found, update emails are sent to subscribed users.
+9. Every email includes a signed unsubscribe link.
+10. The user can also unsubscribe from the in-app subscription drawer.
+
+## Main Files
+
+Core server files:
+
+- [src/pages/api/subscribe.ts](/Users/dhanushlnaik/Workspace/Dev/Avarch/EIPUI/src/pages/api/subscribe.ts)
+- [src/pages/api/subscriptions.ts](/Users/dhanushlnaik/Workspace/Dev/Avarch/EIPUI/src/pages/api/subscriptions.ts)
+- [src/pages/api/unsubscribe.ts](/Users/dhanushlnaik/Workspace/Dev/Avarch/EIPUI/src/pages/api/unsubscribe.ts)
+- [src/utils/subscriptions.ts](/Users/dhanushlnaik/Workspace/Dev/Avarch/EIPUI/src/utils/subscriptions.ts)
+- [src/utils/sync.ts](/Users/dhanushlnaik/Workspace/Dev/Avarch/EIPUI/src/utils/sync.ts)
+- [src/utils/trackChanges.ts](/Users/dhanushlnaik/Workspace/Dev/Avarch/EIPUI/src/utils/trackChanges.ts)
+- [src/utils/email.ts](/Users/dhanushlnaik/Workspace/Dev/Avarch/EIPUI/src/utils/email.ts)
+- [src/utils/mailer.ts](/Users/dhanushlnaik/Workspace/Dev/Avarch/EIPUI/src/utils/mailer.ts)
+- [src/utils/subscriptionLinks.ts](/Users/dhanushlnaik/Workspace/Dev/Avarch/EIPUI/src/utils/subscriptionLinks.ts)
+
+Main frontend files:
+
+- [src/components/SingleSubscriptionButton.tsx](/Users/dhanushlnaik/Workspace/Dev/Avarch/EIPUI/src/components/SingleSubscriptionButton.tsx)
+- [src/components/SubscribtionButton.tsx](/Users/dhanushlnaik/Workspace/Dev/Avarch/EIPUI/src/components/SubscribtionButton.tsx)
+- [src/components/SubscriptionFloater.tsx](/Users/dhanushlnaik/Workspace/Dev/Avarch/EIPUI/src/components/SubscriptionFloater.tsx)
+- [src/components/SubscriptionForm.tsx](/Users/dhanushlnaik/Workspace/Dev/Avarch/EIPUI/src/components/SubscriptionForm.tsx)
+
+Pages that surface subscription UI:
+
+- [src/pages/eips/[eip-number]/index.tsx](/Users/dhanushlnaik/Workspace/Dev/Avarch/EIPUI/src/pages/eips/[eip-number]/index.tsx)
+- [src/pages/ercs/[erc-number]/index.tsx](/Users/dhanushlnaik/Workspace/Dev/Avarch/EIPUI/src/pages/ercs/[erc-number]/index.tsx)
+- [src/pages/rips/[rip-number]/index.tsx](/Users/dhanushlnaik/Workspace/Dev/Avarch/EIPUI/src/pages/rips/[rip-number]/index.tsx)
+- [src/components/Layout.tsx](/Users/dhanushlnaik/Workspace/Dev/Avarch/EIPUI/src/components/Layout.tsx)
+
+## Where Users Subscribe
+
+### 1. Proposal detail pages
+
+Each individual proposal page shows a "Get Updates" row in its metadata table.
+
+Examples:
+
+- EIP detail page uses `SingleSubscriptionButton type="eips" id={eipNo}`
+- ERC detail page uses `SingleSubscriptionButton type="ercs" id={ercNo}`
+- RIP detail page uses `SingleSubscriptionButton type="rips" id={RIPNo}`
+
+This is the main supported subscription path.
+
+### 2. Global subscription drawer
+
+The site layout includes a floating subscription drawer. It is rendered from:
+
+- [src/components/Layout.tsx](/Users/dhanushlnaik/Workspace/Dev/Avarch/EIPUI/src/components/Layout.tsx)
+
+That drawer:
+
+- loads the current user’s subscriptions,
+- groups/filter them by type,
+- allows in-app unsubscribe.
+
+### 3. Generic subscription components
+
+There is also a generic form/button layer:
+
+- `SubscribtionButton`
+- `SubscriptionForm`
+
+These still point at the same APIs, but the current intended user journey is proposal-level subscribe from the detail pages.
+
+## Authentication Model
+
+Subscriptions are session-bound.
+
+That means:
+
+- the server determines the subscriber email from the active NextAuth session,
+- the frontend no longer supplies arbitrary email addresses to subscription APIs,
+- the current user can only list or modify their own subscriptions in-app.
+
+Relevant auth configuration is in:
+
+- [src/pages/api/auth/[...nextauth].ts](/Users/dhanushlnaik/Workspace/Dev/Avarch/EIPUI/src/pages/api/auth/[...nextauth].ts)
+
+## Data Model
+
+### MongoDB collection: `subscriptions`
+
+Each subscription row stores:
+
+- `email`
+- `type`
+- `id`
+- `filter`
+- `createdAt`
+
+Defined in:
+
+- [src/utils/subscriptions.ts](/Users/dhanushlnaik/Workspace/Dev/Avarch/EIPUI/src/utils/subscriptions.ts)
+
+Current supported values:
+
+- `type`: `eips` | `ercs` | `rips`
+- `filter`: `all` | `status` | `content`
+
+Example logical record:
+
+```json
+{
+  "email": "user@example.com",
+  "type": "eips",
+  "id": "1559",
+  "filter": "all",
+  "createdAt": "2026-03-13T10:00:00.000Z"
+}
+```
+
+### MongoDB collection: `change_state`
+
+This collection tracks the last processed Git commit SHA per `(type, id)` so the sync job knows where it left off.
+
+Stored fields:
+
+- `type`
+- `id`
+- `lastSha`
+- `updatedAt`
+
+Managed in:
+
+- [src/utils/subscriptions.ts](/Users/dhanushlnaik/Workspace/Dev/Avarch/EIPUI/src/utils/subscriptions.ts)
+
+## API Endpoints
+
+### `POST /api/subscribe`
+
+File:
+
+- [src/pages/api/subscribe.ts](/Users/dhanushlnaik/Workspace/Dev/Avarch/EIPUI/src/pages/api/subscribe.ts)
+
+Behavior:
+
+- requires a signed-in session,
+- reads `type`, `id`, `filter` from request body,
+- uses `session.user.email` as the subscriber email,
+- validates allowed `type` and `filter` values,
+- checks for an existing identical subscription,
+- inserts the subscription,
+- sends a confirmation email,
+- returns `{ success: true }` on success.
+
+Duplicate subscriptions are rejected with `409`.
+
+### `GET /api/subscriptions`
+
+File:
+
+- [src/pages/api/subscriptions.ts](/Users/dhanushlnaik/Workspace/Dev/Avarch/EIPUI/src/pages/api/subscriptions.ts)
+
+Behavior:
+
+- requires a signed-in session,
+- ignores caller-supplied email as the source of truth,
+- fetches subscriptions for `session.user.email`,
+- returns the current user’s subscription rows.
+
+Note:
+
+Some frontend callers still append `?email=...` in the URL. The server now uses the session email instead, so the query string is effectively redundant.
+
+### `POST /api/unsubscribe`
+
+File:
+
+- [src/pages/api/unsubscribe.ts](/Users/dhanushlnaik/Workspace/Dev/Avarch/EIPUI/src/pages/api/unsubscribe.ts)
+
+Behavior:
+
+- requires a signed-in session,
+- reads `type`, `id`, `filter`,
+- uses `session.user.email`,
+- deletes the exact matching subscription row,
+- returns `{ success: true }`.
+
+### `GET /api/unsubscribe?token=...`
+
+File:
+
+- [src/pages/api/unsubscribe.ts](/Users/dhanushlnaik/Workspace/Dev/Avarch/EIPUI/src/pages/api/unsubscribe.ts)
+
+Behavior:
+
+- used by email unsubscribe links,
+- validates a signed token,
+- extracts `email`, `type`, `id`, `filter`,
+- deletes the exact matching subscription,
+- returns a simple text response.
+
+This path is intentionally stateless so a user can unsubscribe from an email client without needing to sign in first.
+
+## Frontend Behavior
+
+### `SingleSubscriptionButton`
+
+File:
+
+- [src/components/SingleSubscriptionButton.tsx](/Users/dhanushlnaik/Workspace/Dev/Avarch/EIPUI/src/components/SingleSubscriptionButton.tsx)
+
+What it does:
+
+- checks current subscription state on mount,
+- if not signed in, sends user to `signIn(...)`,
+- if signed in, posts to `/api/subscribe` or `/api/unsubscribe`,
+- toggles button label and color based on subscription state.
+
+Used on:
+
+- EIP detail pages
+- ERC detail pages
+- RIP detail pages
+
+### `SubscriptionFloater`
+
+File:
+
+- [src/components/SubscriptionFloater.tsx](/Users/dhanushlnaik/Workspace/Dev/Avarch/EIPUI/src/components/SubscriptionFloater.tsx)
+
+What it does:
+
+- fetches current user subscriptions,
+- shows them in a drawer,
+- filters by `all`, `eips`, `ercs`, `rips`,
+- unsubscribes a specific `(type, id, filter)` record,
+- displays whether the subscription is for `all`, `status`, or `content` changes.
+
+### `SubscribtionButton`
+
+File:
+
+- [src/components/SubscribtionButton.tsx](/Users/dhanushlnaik/Workspace/Dev/Avarch/EIPUI/src/components/SubscribtionButton.tsx)
+
+This is a more generic button wrapper around the same subscription APIs.
+
+It now behaves consistently with the session-bound server flow.
+
+### `SubscriptionForm`
+
+File:
+
+- [src/components/SubscriptionForm.tsx](/Users/dhanushlnaik/Workspace/Dev/Avarch/EIPUI/src/components/SubscriptionForm.tsx)
+
+What it does now:
+
+- requires sign-in,
+- lets the user choose `type`, `id`, and `filter`,
+- posts to `/api/subscribe`,
+- does not directly collect an arbitrary email anymore.
+
+## Confirmation Email Flow
+
+When a user subscribes successfully, the server sends a confirmation email immediately.
+
+Implemented in:
+
+- [src/utils/mailer.ts](/Users/dhanushlnaik/Workspace/Dev/Avarch/EIPUI/src/utils/mailer.ts)
+
+Transport config uses:
+
+- `EMAIL_HOST`
+- `EMAIL_PORT`
+- `EMAIL_USERNAME`
+- `EMAIL_PASSWORD`
+- `EMAIL_FROM`
+
+The confirmation email includes:
+
+- proposal label such as `EIPS-1559`,
+- a short success message,
+- a direct unsubscribe link for that exact subscription.
+
+## Change Detection and Update Emails
+
+### Trigger points
+
+Change sync can be triggered from:
+
+- [src/pages/api/cron/sync.ts](/Users/dhanushlnaik/Workspace/Dev/Avarch/EIPUI/src/pages/api/cron/sync.ts)
+- [src/pages/api/webhooks/github.ts](/Users/dhanushlnaik/Workspace/Dev/Avarch/EIPUI/src/pages/api/webhooks/github.ts)
+
+Both call:
+
+- [src/utils/sync.ts](/Users/dhanushlnaik/Workspace/Dev/Avarch/EIPUI/src/utils/sync.ts)
+
+### Sync algorithm
+
+`syncEipChanges()` does this:
+
+1. Load all subscriptions.
+2. Group them by `(type, id)`.
+3. Read the last processed SHA from `change_state`.
+4. Fetch new GitHub commits for the proposal file.
+5. Convert commits into change events.
+6. Split events into:
+   - `status`
+   - `content`
+7. Filter per subscriber based on their `filter`.
+8. Send update email if there are relevant events.
+9. Generate an RSS file for that proposal.
+10. If all subscriber emails succeeded, advance `lastSha`.
+
+### How file tracking works
+
+The GitHub file path is resolved from `type` and `id` in:
+
+- [src/utils/trackChanges.ts](/Users/dhanushlnaik/Workspace/Dev/Avarch/EIPUI/src/utils/trackChanges.ts)
+
+Mappings:
+
+- `eips` -> `ethereum/EIPs` -> `EIPS/eip-{id}.md`
+- `ercs` -> `ethereum/EIPs` -> `ERCS/erc-{id}.md`
+- `rips` -> `ethereum-cat-herders/RIPs` -> `RIPS/rip-{id}.md`
+
+This is why subscriptions must point to a real proposal id. A fake id like `"all"` would not map to a real file.
+
+### Event generation
+
+Each tracked commit becomes a `content` event.
+
+If the parsed `status:` field changes between revisions, an additional `status` event is created.
+
+That logic lives in:
+
+- [src/utils/trackChanges.ts](/Users/dhanushlnaik/Workspace/Dev/Avarch/EIPUI/src/utils/trackChanges.ts)
+
+### Update email rendering
+
+Update emails are built in:
+
+- [src/utils/email.ts](/Users/dhanushlnaik/Workspace/Dev/Avarch/EIPUI/src/utils/email.ts)
+
+These emails include:
+
+- the proposal label,
+- a table of detected changes,
+- commit links,
+- author and timestamp,
+- an unsubscribe link for the exact subscription.
+
+## Unsubscribe Token Design
+
+The email unsubscribe flow uses a signed token helper in:
+
+- [src/utils/subscriptionLinks.ts](/Users/dhanushlnaik/Workspace/Dev/Avarch/EIPUI/src/utils/subscriptionLinks.ts)
+
+The token encodes:
+
+- `email`
+- `type`
+- `id`
+- `filter`
+- token version
+
+The token is signed with `NEXTAUTH_SECRET` via HMAC SHA-256.
+
+This gives the app a way to verify that the unsubscribe request was created by the server and was not tampered with.
+
+## Supported Filters
+
+The system currently supports three subscription scopes per proposal:
+
+- `all`: send both content and status updates
+- `status`: send only status transitions
+- `content`: send any content changes
+
+The main detail-page buttons currently subscribe with `filter: "all"`.
+
+The data model and backend already support `status` and `content`, and the drawer can display them.
+
+## What Changed Recently
+
+The subscription flow was tightened up to fix a few important problems:
+
+- subscriptions are now tied to the signed-in session on the server,
+- in-app listing no longer trusts arbitrary email query input,
+- in-app unsubscribe no longer trusts arbitrary posted email,
+- email notifications now include working unsubscribe links,
+- misleading aggregate "subscribe to all EIPs/ERCs/RIPs" buttons were removed from overview pages because they did not map to a valid tracked file.
+
+## Current Limitations
+
+### 1. No global repository-wide subscription
+
+This system does not support:
+
+- "all EIPs"
+- "all ERCs"
+- "all RIPs"
+
+It is proposal-specific by design.
+
+### 2. Some frontend calls still include `?email=...`
+
+Some components still request:
+
+- `/api/subscriptions?email=${session.user.email}`
+
+This is harmless now because the server uses session email, but the query parameter is legacy and can be cleaned up later.
+
+### 3. UI feedback still uses `alert(...)`
+
+Several components still use browser alerts for success/error states instead of Chakra toasts.
+
+This is a UX issue, not a functional issue.
+
+### 4. Token unsubscribe response is plain text
+
+The email unsubscribe route currently returns a simple text response, not a styled confirmation page.
+
+### 5. No tests around subscription flow yet
+
+There are no dedicated automated tests in this repo for:
+
+- subscription API auth behavior,
+- duplicate prevention,
+- tokenized unsubscribe,
+- sync-driven email dispatch.
+
+## Environment Variables Relevant to Subscriptions
+
+Required for DB/auth/email:
+
+- `MONGODB_URI`
+- `NEXTAUTH_SECRET`
+- `NEXTAUTH_URL`
+- `EMAIL_HOST`
+- `EMAIL_PORT`
+- `EMAIL_USERNAME`
+- `EMAIL_PASSWORD`
+- `EMAIL_FROM`
+- `GITHUB_TOKEN`
+
+Why each matters:
+
+- `MONGODB_URI`: stores subscriptions and sync state
+- `NEXTAUTH_SECRET`: signs session tokens and unsubscribe links
+- `NEXTAUTH_URL`: builds absolute unsubscribe URLs
+- email variables: send confirmation and update emails
+- `GITHUB_TOKEN`: reads proposal file history from GitHub
+
+See:
+
+- [.env.example](/Users/dhanushlnaik/Workspace/Dev/Avarch/EIPUI/.env.example)
+
+## Recommended Mental Model
+
+If you want to understand the system quickly, think of it as two layers:
+
+### Layer 1: Subscription registry
+
+MongoDB stores "user X wants updates for proposal Y with filter Z".
+
+### Layer 2: Change broadcast
+
+A sync process checks proposal files in GitHub and sends emails when matching changes appear.
+
+That separation is important:
+
+- the API layer manages who is subscribed,
+- the sync layer decides when an update is worth sending.
+
+## Future Improvements
+
+If we continue this area, the natural next improvements are:
+
+1. Replace all `alert(...)` usage with Chakra toasts.
+2. Remove the legacy `?email=...` query usage in frontend subscription fetches.
+3. Add tests for subscribe, unsubscribe, and token validation.
+4. Add a branded unsubscribe confirmation page instead of plain text.
+5. Add explicit filter selection in the individual proposal page UI.
+

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,7 +1,22 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
+const ADMIN_USERNAME = 'admin';
+const ADMIN_PASSWORD = 'eipsinsightv3';
+const AUTH_REALM = 'EIPs Insight V3 Admin';
+
 export function middleware(request: NextRequest) {
+  const authHeader = request.headers.get('authorization');
+
+  if (!isAuthorized(authHeader)) {
+    return new NextResponse('Authentication required.', {
+      status: 401,
+      headers: {
+        'WWW-Authenticate': `Basic realm="${AUTH_REALM}", charset="UTF-8"`,
+      },
+    });
+  }
+
   const path = request.nextUrl.pathname;
 
   // Check if the path is '/reviewers' in any case format
@@ -23,3 +38,25 @@ export function middleware(request: NextRequest) {
 
   return NextResponse.next();
 }
+
+function isAuthorized(authHeader: string | null): boolean {
+  if (!authHeader || !authHeader.startsWith('Basic ')) return false;
+
+  try {
+    const encodedCredentials = authHeader.split(' ')[1] ?? '';
+    const decoded = atob(encodedCredentials);
+    const separatorIndex = decoded.indexOf(':');
+    if (separatorIndex < 0) return false;
+
+    const username = decoded.slice(0, separatorIndex);
+    const password = decoded.slice(separatorIndex + 1);
+
+    return username === ADMIN_USERNAME && password === ADMIN_PASSWORD;
+  } catch {
+    return false;
+  }
+}
+
+export const config = {
+  matcher: '/:path*',
+};

--- a/src/components/SingleSubscriptionButton.tsx
+++ b/src/components/SingleSubscriptionButton.tsx
@@ -178,7 +178,6 @@ export default function SingleSubscriptionButton({ type, id }: SingleSubscriptio
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          email: session.user?.email,
           type,
           id,
           filter: "all",
@@ -205,7 +204,6 @@ export default function SingleSubscriptionButton({ type, id }: SingleSubscriptio
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          email: session?.user?.email,
           type,
           id,
           filter: "all",

--- a/src/components/SubscribtionButton.tsx
+++ b/src/components/SubscribtionButton.tsx
@@ -95,7 +95,6 @@ export default function SubscriptionButton({ type, id }: {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          email: session.user.email,
           type,
           id,
           filter: "all",
@@ -123,7 +122,6 @@ export default function SubscriptionButton({ type, id }: {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          email: session?.user?.email,
           type,
           id,
           filter: "all",
@@ -158,7 +156,7 @@ export default function SubscriptionButton({ type, id }: {
           : "Subscribing..."
         : isSubscribed
           ? `Unsubscribe from ${type.toUpperCase()}-${id}`
-          : `Subscribe to All ${type.toUpperCase()}s`}
+          : `Subscribe to ${type.toUpperCase()}-${id}`}
     </button>
   );
 }

--- a/src/components/SubscriptionFloater.tsx
+++ b/src/components/SubscriptionFloater.tsx
@@ -55,7 +55,6 @@ const SubscriptionFloater = () => {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          email: session?.user?.email,
           type: sub.type,
           id: sub.id,
           filter: sub.filter,
@@ -63,7 +62,7 @@ const SubscriptionFloater = () => {
       });
 
       setSubscriptions(prev =>
-        prev.filter(s => !(s.type === sub.type && s.id === sub.id))
+        prev.filter(s => !(s.type === sub.type && s.id === sub.id && s.filter === sub.filter))
       );
     } catch (err) {
       console.error("Unsubscribe failed", err);
@@ -193,7 +192,7 @@ const SubscriptionFloater = () => {
                               {sub.type.toUpperCase()}-{sub.id}
                             </Text>
                             <Text fontSize="sm" color="gray.500">
-                              {sub.filter === "all" ? "All changes" : "Status only"}
+                              {sub.filter === "all" ? "All changes" : sub.filter === "content" ? "Content only" : "Status only"}
                             </Text>
                           </Box>
                           <Button

--- a/src/components/SubscriptionForm.tsx
+++ b/src/components/SubscriptionForm.tsx
@@ -91,6 +91,7 @@
 
 "use client";
 import { useState, useEffect } from "react";
+import { signIn, useSession } from "next-auth/react";
 
 interface SubscribeFormProps {
   type?: "eips" | "ercs" | "rips";
@@ -99,71 +100,41 @@ interface SubscribeFormProps {
 }
 
 export function SubscribeForm({ type = "eips", id = "", filter = "all" }: SubscribeFormProps) {
-  const [userEmail, setUserEmail] = useState<string | null>(null);
+  const { data: session } = useSession();
   const [selectedType, setSelectedType] = useState(type);
   const [selectedId, setSelectedId] = useState(id.toString());
   const [selectedFilter, setSelectedFilter] = useState(filter);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
-    const stored = localStorage.getItem("user");
-
-    if (!stored) {
-      setLoading(false);
-      return;
-    }
-
-    try {
-      const parsed = JSON.parse(stored);
-      const email = parsed.email;
-
-      fetch(`/api/user/me?email=${email}`)
-        .then((res) => res.json())
-        .then((data) => {
-          if (data?.email) {
-            setUserEmail(data.email);
-          }
-        })
-        .finally(() => setLoading(false));
-    } catch (err) {
-      console.error("Failed to fetch verified user", err);
-      setLoading(false);
-    }
-  }, []);
+    setSelectedType(type);
+    setSelectedId(id.toString());
+    setSelectedFilter(filter);
+  }, [type, id, filter]);
 
   async function subscribe() {
-    const finalEmail = userEmail;
-    if (!finalEmail) {
-      alert("Email not found");
+    if (!session?.user?.email) {
+      signIn(undefined, { callbackUrl: window.location.href });
       return;
     }
 
+    setLoading(true);
     await fetch("/api/subscribe", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        email: finalEmail,
         type: selectedType,
         id: selectedId,
         filter: selectedFilter,
       }),
     });
 
+    setLoading(false);
     alert("Subscribed successfully!");
   }
 
-  if (loading) return <p>Loading...</p>;
-
   return (
     <form onSubmit={(e) => { e.preventDefault(); subscribe(); }} className="space-y-4 p-4 bg-white rounded-xl shadow-md">
-      {!userEmail && (
-        <input
-          placeholder="Enter your email"
-          className="w-full p-2 border rounded"
-          onChange={(e) => setUserEmail(e.target.value)}
-        />
-      )}
-
       <select value={selectedType} onChange={(e) => setSelectedType(e.target.value as any)} className="w-full p-2 border rounded">
         <option value="eips">EIP</option>
         <option value="ercs">ERC</option>
@@ -187,8 +158,8 @@ export function SubscribeForm({ type = "eips", id = "", filter = "all" }: Subscr
         <option value="content">Content Only</option>
       </select>
 
-      <button type="submit" className="w-full bg-blue-600 text-white p-2 rounded">
-        Subscribe
+      <button type="submit" className="w-full bg-blue-600 text-white p-2 rounded" disabled={loading}>
+        {loading ? "Subscribing..." : session?.user?.email ? "Subscribe" : "Sign in to subscribe"}
       </button>
     </form>
   );

--- a/src/pages/api/subscribe.ts
+++ b/src/pages/api/subscribe.ts
@@ -4,6 +4,7 @@ import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/pages/api/auth/[...nextauth]";
 import { connectToDatabase } from '@/lib/mongodb'; // Add this import
 import { sendSubscriptionEmail } from '@/utils/mailer';
+import { buildUnsubscribeUrl } from '@/utils/subscriptionLinks';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
@@ -11,14 +12,17 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   const session = await getServerSession(req, res, authOptions);
-  let { email, type, id, filter } = req.body;
+  let { type, id, filter } = req.body;
   const allowedFilters = ['all', 'status', 'content'];
+  const allowedTypes = ['eips', 'ercs', 'rips'];
 
-  // Use session email if available
-  const userEmail = session?.user?.email || email;
+  const userEmail = session?.user?.email;
 
   if (!userEmail || !type || !id || !filter) {
     return res.status(400).json({ error: 'Missing required fields' });
+  }
+  if (!allowedTypes.includes(type)) {
+    return res.status(400).json({ error: 'Invalid type value' });
   }
   if (!allowedFilters.includes(filter)) {
     return res.status(400).json({ error: 'Invalid filter value' });
@@ -43,7 +47,16 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     });
 
     // Send confirmation email
-    await sendSubscriptionEmail(userEmail, { type, id });
+    await sendSubscriptionEmail(userEmail, {
+      type,
+      id,
+      unsubscribeUrl: buildUnsubscribeUrl({
+        email: userEmail,
+        type,
+        id: String(id),
+        filter,
+      }),
+    });
 
     return res.status(200).json({ success: true });
   } catch (err) {

--- a/src/pages/api/subscriptions.ts
+++ b/src/pages/api/subscriptions.ts
@@ -1,11 +1,13 @@
 // pages/api/subscriptions.ts
 import { connectToDatabase } from '@/lib/mongodb';
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/pages/api/auth/[...nextauth]";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const { email } = req.query;
-
-  if (!email) return res.status(400).json({ error: 'Missing email' });
+  const session = await getServerSession(req, res, authOptions);
+  const email = session?.user?.email;
+  if (!email) return res.status(401).json({ error: 'Authentication required' });
 
   try {
     const client = await connectToDatabase();

--- a/src/pages/api/unsubscribe.ts
+++ b/src/pages/api/unsubscribe.ts
@@ -1,15 +1,48 @@
 // pages/api/unsubscribe.ts
 import { connectToDatabase } from '@/lib/mongodb';
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/pages/api/auth/[...nextauth]";
+import { parseUnsubscribeToken } from '@/utils/subscriptionLinks';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'GET') {
+    const token = typeof req.query.token === 'string' ? req.query.token : '';
+    const identity = token ? parseUnsubscribeToken(token) : null;
+    if (!identity) {
+      return res.status(400).send('Invalid unsubscribe link');
+    }
+
+    try {
+      const client = await connectToDatabase();
+      const db = client.db('eipsinsight');
+      await db.collection('subscriptions').deleteOne(identity);
+      return res
+        .status(200)
+        .send('You have been unsubscribed successfully.');
+    } catch (err) {
+      console.error('❌ Token unsubscribe error:', err);
+      return res.status(500).send('Failed to unsubscribe.');
+    }
+  }
+
   if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
 
-  const { email, type, id, filter } = req.body;
+  const session = await getServerSession(req, res, authOptions);
+  const email = session?.user?.email;
+  if (!email) {
+    return res.status(401).json({ error: 'Authentication required' });
+  }
+
+  const { type, id, filter } = req.body;
   const allowedFilters = ['all', 'status', 'content'];
+  const allowedTypes = ['eips', 'ercs', 'rips'];
 
   if (!email || !type || !id || !filter) {
     return res.status(400).json({ error: 'Missing fields' });
+  }
+  if (!allowedTypes.includes(type)) {
+    return res.status(400).json({ error: 'Invalid type value' });
   }
   if (!allowedFilters.includes(filter)) {
     return res.status(400).json({ error: 'Invalid filter value' });

--- a/src/pages/eip/index.tsx
+++ b/src/pages/eip/index.tsx
@@ -117,9 +117,7 @@ interface Data {
 import OtherBox from "@/components/OtherStats";
 import EipTable from "@/components/EipTable";
 import { useScrollSpy } from "@/hooks/useScrollSpy";
-import SubscriptionButton from '@/components/SubscribtionButton';
 import Header from "@/components/Header";
-import { SubscribeForm } from '@/components/SubscriptionForm';
 
 
 const ALL_OPTIONS = ["Core", "Networking", "Interface", "Meta", "Informational"];
@@ -360,9 +358,9 @@ const Type = () => {
                 gap={4}
               >
                 {/* Left: Subscription Button */}
-                <div className="flex items-center">
-                  <SubscriptionButton type="eips" id="all" />
-                </div>
+                <Box color="gray.500" fontSize="sm">
+                  Subscribe from an individual EIP page to get proposal-specific updates.
+                </Box>
 
                 {/* Right: Category/Status Buttons */}
                 <ButtonGroup size="md" isAttached>

--- a/src/pages/eips/[eip-number]/index.tsx
+++ b/src/pages/eips/[eip-number]/index.tsx
@@ -42,6 +42,7 @@ import Header from "@/components/Header2";
 import LoaderComponent from "@/components/Loader";
 import { InfoOutlineIcon } from "@chakra-ui/icons";
 import { EipAiSummary } from "@/components/EipAiSummary";
+import glamsterdamTimelineData from "@/data/upgrades/glamsterdam-timeline.json";
 import {
   LineChart,
   Line,
@@ -137,14 +138,6 @@ const TestComponent = () => {
       : `EIP-${eipIdentifier}`;
 
     // Improved status checker that properly checks all arrays
-    const getStatus = (data: UpgradeEntry, eip: string): string | null => {
-      if (data.included.includes(eip)) return 'Included';
-      if (data.scheduled.includes(eip)) return 'SFI';
-      if (data.considered.includes(eip)) return 'CFI';
-      if (data.declined.includes(eip)) return 'DFI';
-      return null;
-    };
-
     // Get latest entries (using proper date sorting)
     const latestPectra = [...PectraData2].sort((a, b) =>
       new Date(b.date).getTime() - new Date(a.date).getTime()
@@ -170,6 +163,8 @@ const TestComponent = () => {
       statuses.push('Pectra-SFI');
     } else if (latestPectra.considered.includes(normalizedEip)) {
       statuses.push('Pectra-CFI');
+    } else if (latestPectra.proposed.includes(normalizedEip)) {
+      statuses.push('Pectra-PFI');
     }
 
     // Check Fusaka status
@@ -181,9 +176,11 @@ const TestComponent = () => {
       statuses.push('Fusaka-SFI');
     } else if (latestFusaka.considered.includes(normalizedEip)) {
       statuses.push('Fusaka-CFI');
+    } else if (latestFusaka.proposed.includes(normalizedEip)) {
+      statuses.push('Fusaka-PFI');
     }
 
-        if (latestGlamsterdam.declined.includes(normalizedEip)) {
+    if (latestGlamsterdam.declined.includes(normalizedEip)) {
       statuses.push('Glamsterdam-DFI');
     } else if (latestGlamsterdam.included.includes(normalizedEip)) {
       statuses.push('Glamsterdam-Included');
@@ -191,6 +188,8 @@ const TestComponent = () => {
       statuses.push('Glamsterdam-SFI');
     } else if (latestGlamsterdam.considered.includes(normalizedEip)) {
       statuses.push('Glamsterdam-CFI');
+    } else if (latestGlamsterdam.proposed.includes(normalizedEip)) {
+      statuses.push('Glamsterdam-PFI');
     }
 
     console.log("statuses: ", statuses);
@@ -395,207 +394,14 @@ const FusakaData: readonly UpgradeEntry[] = [
     declined: [], considered: [] , proposed: []},
 ] as const;
 
-const GlamsterdamData: readonly UpgradeEntry[] = [
-  {
-    date: '2024-09-28',
-    included: [],
-    scheduled: [],
-    declined: [],
-    considered: ['EIP-4762', 'EIP-6800', 'EIP-6873', 'EIP-7545', 'EIP-7667'],
-    proposed: []
-  },
-  {
-    date: '2025-06-09',
-    included: [],
-    scheduled: [],
-    declined: [],
-    considered: ['EIP-4762', 'EIP-6800', 'EIP-6873', 'EIP-7545', 'EIP-7667'],
-    proposed: ['EIP-7793', 'EIP-7843']
-  },
-  {
-    date: '2025-06-10',
-    included: [],
-    scheduled: [],
-    declined: [],
-    considered: ['EIP-4762', 'EIP-6800', 'EIP-6873', 'EIP-7545', 'EIP-7667'],
-    proposed: ['EIP-7793', 'EIP-7843', 'EIP-7919']
-  },
-  {
-    date: '2025-07-04',
-    included: [],
-    scheduled: [],
-    declined: [],
-    considered: [],
-    proposed : ['EIP-6873', 'EIP-7667', 'EIP-7793', 'EIP-7843', 'EIP-7919']
-  },
-  {
-    date: '2025-07-25',
-    included: [],
-    scheduled: [],
-    declined: [],
-    considered: ['EIP-7732', 'EIP-7782', 'EIP-7805'],
-    proposed: ['EIP-6873', 'EIP-7667', 'EIP-7793', 'EIP-7819', 'EIP-7843', 'EIP-7919']
-  },
-  {
-    date: '2025-07-31',
-    included: [],
-    scheduled: [],
-    declined: [],
-    considered: ['EIP-7732', 'EIP-7782', 'EIP-7805', 'EIP-7928'],
-    proposed: ['EIP-6873', 'EIP-7667', 'EIP-7793', 'EIP-7819', 'EIP-7843', 'EIP-7919']  
-  },
-    {
-    date: '2025-08-11',
-    included: [],
-    scheduled: [],
-    declined: [],
-    considered: ['EIP-7732', 'EIP-7782', 'EIP-7805', 'EIP-7928'],
-    proposed: ['EIP-6873', 'EIP-7667', 'EIP-7793', 'EIP-7819', 'EIP-7843', 'EIP-7919', 'EIP-5920', 'EIP-7791', 'EIP-7903', 'EIP-7907', 'EIP-7923' ]  
-  },
-      {
-    date: '2025-08-14',
-    included: [],
-    scheduled: ['EIP-7732',  'EIP-7928'],
-    declined: ['EIP-7782'],
-    considered: [ 'EIP-7805'],
-proposed: [
-  'EIP-2926',
-  'EIP-6873',
-  'EIP-7667',
-  'EIP-7793',
-  'EIP-7819',
-  'EIP-7843',
-  'EIP-7919',
-  'EIP-5920',
-  'EIP-7791',
-  'EIP-7903',
-  'EIP-7907',
-  'EIP-7923',
-  'EIP-7997'
-]
-
-  },
-      {
-    date: '2025-08-27',
-    included: [],
-    scheduled: ['EIP-7732',  'EIP-7928'],
-    declined: ['EIP-7782'],
-    considered: [ 'EIP-7805'],
-proposed: [
-  'EIP-2926',
-  'EIP-6873',
-  'EIP-7667',
-  'EIP-7793',
-  'EIP-7819',
-  'EIP-7843',
-  'EIP-7919',
-  'EIP-5920',
-  'EIP-7791',
-  'EIP-7903',
-  'EIP-7907',
-  'EIP-7923',
-  'EIP-7932',
-  'EIP-7980',
-  'EIP-7981',
-  'EIP-7997',
-  'EIP-7999'
-]
-
-  },
-        {
-    date: '2025-09-04',
-    included: [],
-    scheduled: ['EIP-7732',  'EIP-7928'],
-    declined: ['EIP-7782'],
-    considered: [ 'EIP-7805'],
-proposed: [
-  'EIP-2926',
-  'EIP-6873',
-  'EIP-7667',
-  'EIP-7793',
-  'EIP-7819',
-  'EIP-7843',
-  'EIP-7919',
-  'EIP-5920',
-  'EIP-7791',
-  'EIP-7903',
-  'EIP-7907',
-  'EIP-7923',
-  'EIP-7932',
-  'EIP-7980',
-  'EIP-7981',
-  'EIP-7997',
-  'EIP-7999',
-  'EIP-7778',
-  'EIP-7976',
-  'EIP-7688',
-]
-
-  },
-          {
-    date: '2025-09-12',
-    included: [],
-    scheduled: ['EIP-7732',  'EIP-7928'],
-    declined: ['EIP-7782'],
-    considered: [ 'EIP-7805'],
-proposed: [
-  'EIP-2926',
-  'EIP-6873',
-  'EIP-7667',
-  'EIP-7793',
-  'EIP-7819',
-  'EIP-7843',
-  'EIP-7919',
-  'EIP-5920',
-  'EIP-7791',
-  'EIP-7903',
-  'EIP-7907',
-  'EIP-7923',
-  'EIP-7932',
-  'EIP-7980',
-  'EIP-7981',
-  'EIP-7997',
-  'EIP-7999',
-  'EIP-7778',
-  'EIP-7976',
-  'EIP-7688',
-  'EIP-2780',
-]
-
-  },
-            {
-    date: '2025-09-24',
-    included: [],
-    scheduled: ['EIP-7732',  'EIP-7928'],
-    declined: ['EIP-7782'],
-    considered: [ 'EIP-7805'],
-proposed: [
-  'EIP-2926',
-  'EIP-6873',
-  'EIP-7667',
-  'EIP-7793',
-  'EIP-7819',
-  'EIP-7843',
-  'EIP-7919',
-  'EIP-5920',
-  'EIP-7791',
-  'EIP-7903',
-  'EIP-7907',
-  'EIP-7923',
-  'EIP-7932',
-  'EIP-7980',
-  'EIP-7981',
-  'EIP-7997',
-  'EIP-7999',
-  'EIP-7778',
-  'EIP-7976',
-  'EIP-7688',
-  'EIP-2780',
-  'EIP-7610'
-]
-
-  },
-] as const;
+const GlamsterdamData: readonly UpgradeEntry[] = glamsterdamTimelineData.map((entry) => ({
+  date: entry.date,
+  included: entry.included ?? [],
+  scheduled: entry.scheduled ?? [],
+  declined: entry.declined ?? [],
+  considered: entry.considered ?? [],
+  proposed: entry.proposed ?? [],
+}));
 
   const getNetworkUpgrades = (eipNo: number) => {
     console.log("eip:", eipNo);

--- a/src/pages/erc/index.tsx
+++ b/src/pages/erc/index.tsx
@@ -31,7 +31,6 @@ import CatTable2 from "@/components/CatTable2";
 import ErcTable from "@/components/ErcTable";
 import { useRouter } from "next/router";
 import ERCsPRChart from "@/components/Ercsprs";
-import SubscriptionButton from "@/components/SubscribtionButton";
 
 interface EIP {
   _id: string;
@@ -304,8 +303,8 @@ const ERC = () => {
                 gap={4}
               >
                 {/* Subscription Button (left) */}
-                <Box>
-                  <SubscriptionButton type="ercs" id="all" />
+                <Box color="gray.500" fontSize="sm">
+                  Subscribe from an individual ERC page to get proposal-specific updates.
                 </Box>
 
                 {/* Toggle Buttons (right) */}
@@ -562,4 +561,3 @@ const ERC = () => {
 };
 
 export default ERC;
-

--- a/src/pages/rip/index.tsx
+++ b/src/pages/rip/index.tsx
@@ -25,7 +25,6 @@ import CatTable2 from "@/components/CatTable2";
 import NextLink from "next/link";
 import RipTable from "@/components/RipTable";
 import { useRouter } from "next/router";
-import SubscriptionButton from "@/components/SubscribtionButton";
 import { useScrollSpy } from "@/hooks/useScrollSpy";
 
 interface EIP {
@@ -313,8 +312,8 @@ const RIP = () => {
                 gap={4}
               >
                 {/* Left: Subscription Button */}
-                <Box>
-                  <SubscriptionButton type="rips" id="all" />
+                <Box color="gray.500" fontSize="sm">
+                  Subscribe from an individual RIP page to get proposal-specific updates.
                 </Box>
 
                 {/* Right: Category / Status Toggle Buttons */}

--- a/src/utils/email.ts
+++ b/src/utils/email.ts
@@ -21,8 +21,9 @@ export function buildChangeEmail(params: {
   type: 'eips' | 'ercs' | 'rips';
   id: string | number;
   events: ChangeEvent[];
+  unsubscribeUrl?: string;
 }) {
-  const { type, id, events } = params;
+  const { type, id, events, unsubscribeUrl } = params;
   const title = `${type.toUpperCase()}-${id} Updates`;
   const baseLink =
     type === 'rips'
@@ -84,7 +85,7 @@ export function buildChangeEmail(params: {
       </table>
       <p style="font-size:12px;color:#64748b;margin-top:24px;">
         You received this because you subscribed to ${type.toUpperCase()}-${id} updates.
-        To change preferences or unsubscribe (coming soon), reply to this email.
+        ${unsubscribeUrl ? `<a href="${unsubscribeUrl}" style="color:#2563eb;text-decoration:none;">Unsubscribe from these updates</a>.` : 'Reply to this email if you need help unsubscribing.'}
       </p>
     </div>
   </div>
@@ -103,7 +104,8 @@ export function buildChangeEmail(params: {
         : `CONTENT: ${escapedSummary} | ${escapedMessage} (${e.url})`;
     }),
     '',
-    `More: ${baseLink}`
+    `More: ${baseLink}`,
+    unsubscribeUrl ? `Unsubscribe: ${unsubscribeUrl}` : ''
   ].join('\n');
 
   return { html, text, subject: title };

--- a/src/utils/mailer.ts
+++ b/src/utils/mailer.ts
@@ -12,7 +12,7 @@ export const transporter = nodemailer.createTransport({
 
 export async function sendSubscriptionEmail(
   email: string,
-  subscription: { type: string; id: string }
+  subscription: { type: string; id: string; unsubscribeUrl?: string }
 ) {
   const subscriptionLabel = `${subscription.type.toUpperCase()}-${subscription.id}`;
   const mailOptions = {
@@ -25,6 +25,7 @@ export async function sendSubscriptionEmail(
         <p>Hey there 👋,</p>
         <p>You’ve successfully subscribed to updates on <strong>${subscriptionLabel}</strong>.</p>
         <p>We’ll notify you when there are changes or new discussions related to this ${subscription.type.toUpperCase()}.</p>
+        ${subscription.unsubscribeUrl ? `<p><a href="${subscription.unsubscribeUrl}">Unsubscribe from these updates</a></p>` : ""}
         <p style="margin-top: 20px;">Stay curious,<br/>The EIPs Insight Team</p>
       </div>
     `,

--- a/src/utils/subscriptionLinks.ts
+++ b/src/utils/subscriptionLinks.ts
@@ -1,0 +1,65 @@
+import crypto from "crypto";
+
+const TOKEN_VERSION = "v1";
+
+interface SubscriptionIdentity {
+  email: string;
+  type: string;
+  id: string;
+  filter: string;
+}
+
+function getSecret() {
+  const secret = process.env.NEXTAUTH_SECRET;
+  if (!secret) {
+    throw new Error("Missing NEXTAUTH_SECRET for subscription token signing");
+  }
+  return secret;
+}
+
+function signPayload(payload: string) {
+  return crypto.createHmac("sha256", getSecret()).update(payload).digest("base64url");
+}
+
+export function createUnsubscribeToken(identity: SubscriptionIdentity) {
+  const payload = Buffer.from(
+    JSON.stringify({ ...identity, v: TOKEN_VERSION }),
+    "utf8"
+  ).toString("base64url");
+  const sig = signPayload(payload);
+  return `${payload}.${sig}`;
+}
+
+export function parseUnsubscribeToken(token: string): SubscriptionIdentity | null {
+  const [payload, sig] = token.split(".");
+  if (!payload || !sig) return null;
+  const expectedSig = signPayload(payload);
+  const sigBuffer = Buffer.from(sig);
+  const expectedBuffer = Buffer.from(expectedSig);
+  if (sigBuffer.length !== expectedBuffer.length) {
+    return null;
+  }
+  if (!crypto.timingSafeEqual(sigBuffer, expectedBuffer)) {
+    return null;
+  }
+
+  try {
+    const decoded = JSON.parse(Buffer.from(payload, "base64url").toString("utf8"));
+    if (decoded?.v !== TOKEN_VERSION) return null;
+    if (!decoded.email || !decoded.type || !decoded.id || !decoded.filter) return null;
+    return {
+      email: String(decoded.email),
+      type: String(decoded.type),
+      id: String(decoded.id),
+      filter: String(decoded.filter),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function buildUnsubscribeUrl(identity: SubscriptionIdentity) {
+  const baseUrl = process.env.NEXTAUTH_URL || "http://localhost:3000";
+  const token = createUnsubscribeToken(identity);
+  return `${baseUrl.replace(/\/$/, "")}/api/unsubscribe?token=${encodeURIComponent(token)}`;
+}

--- a/src/utils/sync.ts
+++ b/src/utils/sync.ts
@@ -2,6 +2,7 @@ import { getAllSubscriptions, getLastProcessedSha, setLastProcessedSha } from '.
 import { getChangesSince } from './trackChanges';
 import { buildChangeEmail, sendEmailNotification } from './email';
 import { buildFeedItemsFromEvents, generateRSSFeed } from './rss';
+import { buildUnsubscribeUrl } from './subscriptionLinks';
 import { mkdir, writeFile } from 'fs/promises';
 import path from 'path';
 
@@ -68,8 +69,14 @@ export async function syncEipChanges() {
         const { html, text, subject } = buildChangeEmail({
           type: key.type,
           id: key.id,
-            // De-duplicate status + content that refer to same commit if desired:
-          events: dedupeEvents(relevant)
+          // De-duplicate status + content that refer to same commit if desired:
+          events: dedupeEvents(relevant),
+          unsubscribeUrl: buildUnsubscribeUrl({
+            email: sub.email,
+            type: String(sub.type),
+            id: String(sub.id),
+            filter: String(sub.filter),
+          }),
         });
         await sendEmailNotification({ email: sub.email, subject, html, text });
         console.log(`✅ Notified ${sub.email} (${relevant.length} events)`);


### PR DESCRIPTION
This pull request introduces significant improvements to authentication and subscription management, focusing on requiring user authentication for subscription actions, enhancing unsubscribe flows, and improving the clarity and consistency of the subscription experience. It also adds basic authentication middleware for admin access and refines status detection in EIP upgrade timelines.

**Authentication and Access Control**

* Added a middleware in `middleware.ts` to require HTTP Basic authentication for all routes, protecting admin resources with a username and password prompt. [[1]](diffhunk://#diff-3c67eb27b539c61276d7c7cbcdbe15d4b37a6cbf58bf8bc12c1c4d7619c96d1cR4-R19) [[2]](diffhunk://#diff-3c67eb27b539c61276d7c7cbcdbe15d4b37a6cbf58bf8bc12c1c4d7619c96d1cR41-R62)
* Updated all subscription-related API routes (`/api/subscribe`, `/api/unsubscribe`, `/api/subscriptions`) to require a valid user session (NextAuth), removing support for unauthenticated or email-only access. Now, users must be signed in to subscribe, unsubscribe, or view their subscriptions. [[1]](diffhunk://#diff-bac0e3031300bb063ff8e499f2bfcef6bd00af76b86a4d294c1233fa6e0c6b4dR7-R26) [[2]](diffhunk://#diff-97d77236e489075cc1e18bb438a7c74c8b4b3cb73606e37e0412ab3b4ff03fc5R4-R46) [[3]](diffhunk://#diff-52cc14b49d056b012c6f74b3bc04a58ffe9bcbff3b92ed33b238328d0e9cbdd4R4-R10)

**Subscription and Unsubscribe Flow Improvements**

* Updated frontend subscription forms and buttons to remove email fields and require users to sign in before subscribing or unsubscribing. The UI now prompts users to sign in if needed and disables actions while loading. [[1]](diffhunk://#diff-fad77c58c76a80b855d93a5d40c7b65575e8bfc843bf99b17420fe49bc8caa6dL102-L166) [[2]](diffhunk://#diff-fad77c58c76a80b855d93a5d40c7b65575e8bfc843bf99b17420fe49bc8caa6dL190-R162) [[3]](diffhunk://#diff-f93adf6a697f4e41c595189c9d5ee434d217b1301df4316a02398376f27b5b44L181) [[4]](diffhunk://#diff-f93adf6a697f4e41c595189c9d5ee434d217b1301df4316a02398376f27b5b44L208) [[5]](diffhunk://#diff-a11a0ac7ba229f8e7113624a09b9199f975f86e395dfe229fc64aed93bacb555L98) [[6]](diffhunk://#diff-a11a0ac7ba229f8e7113624a09b9199f975f86e395dfe229fc64aed93bacb555L126)
* Enhanced the unsubscribe API (`/api/unsubscribe`) to support secure one-click unsubscribe links via tokens, allowing users to unsubscribe directly from email links without authentication.
* Subscription confirmation emails now include a personalized unsubscribe link, improving user control and compliance.

**User Experience and UI Improvements**

* Improved the subscription floater and buttons: removed redundant email parameters, clarified filter labeling, and refined the subscribe/unsubscribe button text for better clarity. [[1]](diffhunk://#diff-acd9cf23a45743145687bafc09938baae39b7b8db0de091ea5bed2c4a26f31d1L58-R65) [[2]](diffhunk://#diff-acd9cf23a45743145687bafc09938baae39b7b8db0de091ea5bed2c4a26f31d1L196-R195) [[3]](diffhunk://#diff-a11a0ac7ba229f8e7113624a09b9199f975f86e395dfe229fc64aed93bacb555L161-R159)
* On the EIP list page, replaced the "Subscribe to All" button with a notice directing users to subscribe from individual EIP pages, reducing confusion and clarifying the subscription model. [[1]](diffhunk://#diff-223f23134edc21d4704493171f3cee9bf18ac02e0c7c8fde69e1fd7fcbd1a968L120-L122) [[2]](diffhunk://#diff-223f23134edc21d4704493171f3cee9bf18ac02e0c7c8fde69e1fd7fcbd1a968L363-R363)

**EIP Upgrade Timeline Status Logic**

* Enhanced EIP upgrade status detection by adding support for the "proposed" state (PFI) in Pectra, Fusaka, and Glamsterdam upgrade timelines, providing more granular status reporting for EIPs. ([src/pages/eips/[eip-number]/index.tsxR45](diffhunk://#diff-b1acab2c9b112a09fa333d983825e6d5193da2d3a4c6d07cdda2d3286c8ace9aR45), [src/pages/eips/[eip-number]/index.tsxL140-L147](diffhunk://#diff-b1acab2c9b112a09fa333d983825e6d5193da2d3a4c6d07cdda2d3286c8ace9aL140-L147), [src/pages/eips/[eip-number]/index.tsxR166-R167](diffhunk://#diff-b1acab2c9b112a09fa333d983825e6d5193da2d3a4c6d07cdda2d3286c8ace9aR166-R167), [src/pages/eips/[eip-number]/index.tsxR179-R180](diffhunk://#diff-b1acab2c9b112a09fa333d983825e6d5193da2d3a4c6d07cdda2d3286c8ace9aR179-R180), [src/pages/eips/[eip-number]/index.tsxR191-R192](diffhunk://#diff-b1acab2c9b112a09fa333d983825e6d5193da2d3a4c6d07cdda2d3286c8ace9aR191-R192))